### PR TITLE
POPROG-BACKEND-31 sourceUuid для чата и авто-резолв UUID из сообщений

### DIFF
--- a/docs/gigachat-setup.md
+++ b/docs/gigachat-setup.md
@@ -155,6 +155,7 @@ Swagger:
 curl -X POST http://localhost:8080/api/assistant/chat \
   -H 'Content-Type: application/json' \
   -d '{
+    "document": null,
     "messages": [
       {
         "role": "system",
@@ -172,14 +173,32 @@ curl -X POST http://localhost:8080/api/assistant/chat \
 
 ```json
 {
+  "chatId": "7f4b2a4a-2c9e-4a8f-9d53-9c11dd0a6b15",
   "content": "Привет! Я ИИ-ассистент на базе GigaChat.",
   "model": "GigaChat",
   "finishReason": "stop",
   "promptTokens": 18,
   "completionTokens": 12,
-  "totalTokens": 30
+  "totalTokens": 30,
+  "documentHints": []
 }
 ```
+
+Можно передать конкретный документ для ответов (если известен), иначе сервис подберет релевантные документы сам:
+
+```json
+{
+  "document": {
+    "sourceType": "publication",
+    "sourceUuid": "842786fa-7e33-45ff-8527-8c9dd08441a9"
+  },
+  "messages": [
+    { "role": "user", "content": "Какие инструменты упоминаются в работе?" }
+  ]
+}
+```
+
+Если `document.sourceUuid` не передан, сервис пытается извлечь UUID прямо из текста сообщений и найти документ по этому UUID автоматически.
 
 ## Что проверить, если не работает
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -231,7 +231,7 @@ paths:
       tags:
         - ИИ-ассистент
       summary: Отправить сообщение в чат с ИИ-ассистентом
-      description: Принимает новые сообщения для диалога, при наличии chatId подмешивает сохраненную историю, отправляет запрос в GigaChat и возвращает ответ ассистента.
+      description: Принимает новые сообщения для диалога, при наличии chatId подмешивает сохраненную историю, отправляет запрос в GigaChat и возвращает ответ ассистента. Если document.sourceUuid не задан, сервис извлекает UUID из текста сообщений и проверяет документы по ним; при отсутствии UUID подбирает релевантные документы по вопросу.
       operationId: assistantChat
       requestBody:
         required: true
@@ -595,11 +595,29 @@ components:
             - string
             - "null"
           format: uuid
+        document:
+          anyOf:
+            - $ref: "#/components/schemas/AiAssistantDocumentRefRequest"
+            - type: "null"
         messages:
           type: array
           minItems: 1
           items:
             $ref: "#/components/schemas/AiAssistantChatMessageRequest"
+    AiAssistantDocumentRefRequest:
+      type: object
+      properties:
+        sourceType:
+          type:
+            - string
+            - "null"
+          description: Тип документа (publication или student_work), необязателен для автоподбора
+        sourceUuid:
+          type:
+            - string
+            - "null"
+          format: uuid
+          description: UUID документа, необязателен; если не передан, сервис извлекает UUID из текста сообщений
     AiAssistantChatMessageRequest:
       type: object
       required:
@@ -645,6 +663,51 @@ components:
           type:
             - integer
             - "null"
+        documentHints:
+          type: array
+          description: Подсказки по найденным документам, которые использовались в ответе
+          items:
+            $ref: "#/components/schemas/AiAssistantDocumentHintResponse"
+    AiAssistantDocumentHintResponse:
+      type: object
+      required:
+        - sourceType
+        - scoreHint
+        - groupTitle
+        - authors
+        - theme
+        - published
+        - snippet
+      properties:
+        sourceType:
+          type: string
+          description: Тип документа (publication или student_work)
+        sourceUuid:
+          type:
+            - string
+            - "null"
+          format: uuid
+        scoreHint:
+          type: integer
+          description: Количество совпавших фрагментов
+        groupTitle:
+          type: string
+        groupHash:
+          type:
+            - string
+            - "null"
+        authors:
+          type: string
+        theme:
+          type: string
+        published:
+          type: string
+        link:
+          type:
+            - string
+            - "null"
+        snippet:
+          type: string
     ChatHistoryResponse:
       type: object
       required:

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/assistant/AiAssistantController.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/assistant/AiAssistantController.kt
@@ -1,6 +1,8 @@
 package com.example.poprogknowledgebaseback.adapters.inbound.web.assistant
 
 import com.example.poprogknowledgebaseback.application.assistant.AiAssistantUseCase
+import com.example.poprogknowledgebaseback.application.assistant.AssistantDocumentHint
+import com.example.poprogknowledgebaseback.application.assistant.AssistantDocumentRef
 import com.example.poprogknowledgebaseback.application.assistant.AssistantChatCommand
 import com.example.poprogknowledgebaseback.application.assistant.AssistantChatResult
 import com.example.poprogknowledgebaseback.application.assistant.ChatHistoryMessageResult
@@ -52,7 +54,8 @@ class AiAssistantController(
         aiAssistantUseCase.chat(
             AssistantChatCommand(
                 chatId = request.chatId,
-                messages = request.messages.map { it.toDomain() }
+                messages = request.messages.map { it.toDomain() },
+                documentRef = request.document?.toDomain()
             )
         ).toDto()
 
@@ -86,7 +89,26 @@ class AiAssistantController(
         finishReason = finishReason,
         promptTokens = promptTokens,
         completionTokens = completionTokens,
-        totalTokens = totalTokens
+        totalTokens = totalTokens,
+        documentHints = documentHints.map { it.toDto() }
+    )
+
+    private fun AiAssistantDocumentRefRequest.toDomain() = AssistantDocumentRef(
+        sourceType = sourceType,
+        sourceUuid = sourceUuid
+    )
+
+    private fun AssistantDocumentHint.toDto() = AiAssistantDocumentHintResponse(
+        sourceType = sourceType,
+        sourceUuid = sourceUuid,
+        scoreHint = scoreHint,
+        groupTitle = groupTitle,
+        groupHash = groupHash,
+        authors = authors,
+        theme = theme,
+        published = published,
+        link = link,
+        snippet = snippet
     )
 
     private fun ChatHistoryResult.toDto() = ChatHistoryResponse(

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/assistant/AiAssistantDto.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/assistant/AiAssistantDto.kt
@@ -9,9 +9,15 @@ import java.util.UUID
 
 data class AiAssistantChatRequest(
     val chatId: UUID? = null,
+    val document: AiAssistantDocumentRefRequest? = null,
     @field:Valid
     @field:NotEmpty
     val messages: List<AiAssistantChatMessageRequest>
+)
+
+data class AiAssistantDocumentRefRequest(
+    val sourceType: String? = null,
+    val sourceUuid: String? = null
 )
 
 data class AiAssistantChatMessageRequest(
@@ -28,7 +34,21 @@ data class AiAssistantChatResponse(
     val finishReason: String?,
     val promptTokens: Int?,
     val completionTokens: Int?,
-    val totalTokens: Int?
+    val totalTokens: Int?,
+    val documentHints: List<AiAssistantDocumentHintResponse> = emptyList()
+)
+
+data class AiAssistantDocumentHintResponse(
+    val sourceType: String,
+    val sourceUuid: String?,
+    val scoreHint: Int,
+    val groupTitle: String,
+    val groupHash: String?,
+    val authors: String,
+    val theme: String,
+    val published: String,
+    val link: String?,
+    val snippet: String
 )
 
 data class ChatHistoryResponse(

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/ElasticsearchSearchChunkIndexAdapter.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/ElasticsearchSearchChunkIndexAdapter.kt
@@ -6,6 +6,7 @@ import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
 import com.example.poprogknowledgebaseback.domain.search.port.SearchChunkIndexPort
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.data.elasticsearch.client.elc.NativeQuery
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates
@@ -62,7 +63,13 @@ class ElasticsearchSearchChunkIndexAdapter(
             }
             .build()
 
-        operations.delete(query, SearchChunkDocument::class.java, indexCoordinates)
+        val idsToDelete = operations.search(query, SearchChunkDocument::class.java, indexCoordinates)
+            .searchHits
+            .mapNotNull { it.id }
+
+        if (idsToDelete.isNotEmpty()) {
+            repository.deleteAllById(idsToDelete)
+        }
     }
 
     override fun search(
@@ -123,6 +130,26 @@ class ElasticsearchSearchChunkIndexAdapter(
                         .minimumShouldMatch("1")
                 }
             }
+            .withPageable(PageRequest.of(0, limit))
+            .build()
+
+        return operations.search(nativeQuery, SearchChunkDocument::class.java)
+            .searchHits
+            .map { it.content.toDomain() }
+    }
+
+    override fun findBySource(sourceType: SearchSourceType, sourceId: Long, limit: Int): List<SearchChunk> {
+        val nativeQuery = NativeQuery.builder()
+            .withQuery { q ->
+                q.bool { bool ->
+                    bool.filter { filter ->
+                        filter.term { term -> term.field("sourceType").value(sourceType.name) }
+                    }.filter { filter ->
+                        filter.term { term -> term.field("sourceId").value(sourceId) }
+                    }
+                }
+            }
+            .withSort(Sort.by(Sort.Order.asc("chunkIndex")))
             .withPageable(PageRequest.of(0, limit))
             .build()
 

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/ElasticsearchSearchChunkIndexAdapter.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/ElasticsearchSearchChunkIndexAdapter.kt
@@ -1,0 +1,169 @@
+package com.example.poprogknowledgebaseback.adapters.outbound.search.elasticsearch
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Operator
+import com.example.poprogknowledgebaseback.domain.search.SearchChunk
+import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
+import com.example.poprogknowledgebaseback.domain.search.port.SearchChunkIndexPort
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.elasticsearch.client.elc.NativeQuery
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["app.search.enabled"], havingValue = "true", matchIfMissing = true)
+class ElasticsearchSearchChunkIndexAdapter(
+    private val repository: SearchChunkDocumentRepository,
+    private val operations: ElasticsearchOperations
+) : SearchChunkIndexPort {
+
+    companion object {
+        private const val MIN_PARTIAL_QUERY_LENGTH = 3
+    }
+
+    override fun replaceAll(chunks: List<SearchChunk>) {
+        val indexCoordinates = IndexCoordinates.of("knowledge_chunks")
+
+        if (operations.indexOps(indexCoordinates).exists()) {
+            operations.indexOps(indexCoordinates).delete()
+        }
+
+        operations.indexOps(SearchChunkDocument::class.java).create()
+        operations.indexOps(SearchChunkDocument::class.java).putMapping()
+
+        repository.saveAll(chunks.map { it.toDocument() })
+    }
+
+    override fun index(chunks: List<SearchChunk>) {
+        if (chunks.isEmpty()) {
+            return
+        }
+
+        ensureIndex()
+        repository.saveAll(chunks.map { it.toDocument() })
+    }
+
+    override fun deleteBySource(sourceType: SearchSourceType, sourceId: Long) {
+        val indexCoordinates = IndexCoordinates.of("knowledge_chunks")
+        if (!operations.indexOps(indexCoordinates).exists()) {
+            return
+        }
+
+        val query = NativeQuery.builder()
+            .withQuery { q ->
+                q.bool { bool ->
+                    bool.filter { filter ->
+                        filter.term { term -> term.field("sourceType").value(sourceType.name) }
+                    }.filter { filter ->
+                        filter.term { term -> term.field("sourceId").value(sourceId) }
+                    }
+                }
+            }
+            .build()
+
+        operations.delete(query, SearchChunkDocument::class.java, indexCoordinates)
+    }
+
+    override fun search(
+        query: String,
+        limit: Int,
+        sourceType: SearchSourceType?,
+        sourceId: Long?
+    ): List<SearchChunk> {
+        if (query.length < MIN_PARTIAL_QUERY_LENGTH) {
+            return emptyList()
+        }
+
+        val nativeQuery = NativeQuery.builder()
+            .withQuery { q ->
+                q.bool { bool ->
+                    if (sourceType != null) {
+                        bool.filter { filter ->
+                            filter.term { term -> term.field("sourceType").value(sourceType.name) }
+                        }
+                    }
+                    if (sourceId != null) {
+                        bool.filter { filter ->
+                            filter.term { term -> term.field("sourceId").value(sourceId) }
+                        }
+                    }
+
+                    bool
+                        .should { should ->
+                            should.multiMatch { multiMatch ->
+                                multiMatch
+                                    .query(query)
+                                    .operator(Operator.Or)
+                                    .fields(
+                                        "content^4",
+                                        "theme^2",
+                                        "authors^2",
+                                        "groupTitle",
+                                        "published",
+                                        "groupHash"
+                                    )
+                            }
+                        }
+                        .should { should ->
+                            should.multiMatch { multiMatch ->
+                                multiMatch
+                                    .query(query)
+                                    .operator(Operator.Or)
+                                    .fields(
+                                        "content.partial^4",
+                                        "theme.partial^2",
+                                        "authors.partial^2",
+                                        "groupTitle.partial",
+                                        "published.partial",
+                                        "groupHash.partial"
+                                    )
+                            }
+                        }
+                        .minimumShouldMatch("1")
+                }
+            }
+            .withPageable(PageRequest.of(0, limit))
+            .build()
+
+        return operations.search(nativeQuery, SearchChunkDocument::class.java)
+            .searchHits
+            .map { it.content.toDomain() }
+    }
+
+    private fun ensureIndex() {
+        val indexOps = operations.indexOps(IndexCoordinates.of("knowledge_chunks"))
+        if (!indexOps.exists()) {
+            operations.indexOps(SearchChunkDocument::class.java).create()
+            operations.indexOps(SearchChunkDocument::class.java).putMapping()
+        }
+    }
+
+    private fun SearchChunk.toDocument() = SearchChunkDocument(
+        id = id,
+        sourceType = sourceType.name,
+        sourceId = sourceId,
+        chunkIndex = chunkIndex,
+        content = content,
+        groupTitle = groupTitle,
+        groupHash = groupHash,
+        authors = authors,
+        theme = theme,
+        published = published,
+        link = link
+    )
+
+    private fun SearchChunkDocument.toDomain() = SearchChunk(
+        id = id,
+        sourceType = SearchSourceType.valueOf(sourceType),
+        sourceId = sourceId,
+        chunkIndex = chunkIndex,
+        content = content,
+        groupTitle = groupTitle,
+        groupHash = groupHash,
+        authors = authors,
+        theme = theme,
+        published = published,
+        link = link
+    )
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/NoOpSearchChunkIndexAdapter.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/NoOpSearchChunkIndexAdapter.kt
@@ -12,6 +12,7 @@ class NoOpSearchChunkIndexAdapter : SearchChunkIndexPort {
     override fun replaceAll(chunks: List<SearchChunk>) = Unit
     override fun index(chunks: List<SearchChunk>) = Unit
     override fun deleteBySource(sourceType: SearchSourceType, sourceId: Long) = Unit
+    override fun findBySource(sourceType: SearchSourceType, sourceId: Long, limit: Int): List<SearchChunk> = emptyList()
 
     override fun search(
         query: String,

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/NoOpSearchChunkIndexAdapter.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/NoOpSearchChunkIndexAdapter.kt
@@ -1,0 +1,22 @@
+package com.example.poprogknowledgebaseback.adapters.outbound.search.elasticsearch
+
+import com.example.poprogknowledgebaseback.domain.search.SearchChunk
+import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
+import com.example.poprogknowledgebaseback.domain.search.port.SearchChunkIndexPort
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+@Component
+@ConditionalOnProperty(name = ["app.search.enabled"], havingValue = "false")
+class NoOpSearchChunkIndexAdapter : SearchChunkIndexPort {
+    override fun replaceAll(chunks: List<SearchChunk>) = Unit
+    override fun index(chunks: List<SearchChunk>) = Unit
+    override fun deleteBySource(sourceType: SearchSourceType, sourceId: Long) = Unit
+
+    override fun search(
+        query: String,
+        limit: Int,
+        sourceType: SearchSourceType?,
+        sourceId: Long?
+    ): List<SearchChunk> = emptyList()
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/SearchChunkDocument.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/SearchChunkDocument.kt
@@ -1,0 +1,97 @@
+package com.example.poprogknowledgebaseback.adapters.outbound.search.elasticsearch
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.elasticsearch.annotations.Document
+import org.springframework.data.elasticsearch.annotations.Field
+import org.springframework.data.elasticsearch.annotations.FieldType
+import org.springframework.data.elasticsearch.annotations.InnerField
+import org.springframework.data.elasticsearch.annotations.MultiField
+import org.springframework.data.elasticsearch.annotations.Setting
+
+@Document(indexName = "knowledge_chunks")
+@Setting(settingPath = "elasticsearch/knowledge-search-settings.json")
+data class SearchChunkDocument(
+    @Id
+    val id: String,
+    @Field(type = FieldType.Keyword)
+    val sourceType: String,
+    @Field(type = FieldType.Long)
+    val sourceId: Long,
+    @Field(type = FieldType.Integer)
+    val chunkIndex: Int,
+    @MultiField(
+        mainField = Field(type = FieldType.Text),
+        otherFields = [
+            InnerField(
+                suffix = "partial",
+                type = FieldType.Text,
+                analyzer = "partial_index",
+                searchAnalyzer = "partial_search"
+            )
+        ]
+    )
+    val content: String,
+    @MultiField(
+        mainField = Field(type = FieldType.Text),
+        otherFields = [
+            InnerField(
+                suffix = "partial",
+                type = FieldType.Text,
+                analyzer = "partial_index",
+                searchAnalyzer = "partial_search"
+            )
+        ]
+    )
+    val groupTitle: String,
+    @MultiField(
+        mainField = Field(type = FieldType.Text),
+        otherFields = [
+            InnerField(suffix = "keyword", type = FieldType.Keyword),
+            InnerField(
+                suffix = "partial",
+                type = FieldType.Text,
+                analyzer = "partial_index",
+                searchAnalyzer = "partial_search"
+            )
+        ]
+    )
+    val groupHash: String? = null,
+    @MultiField(
+        mainField = Field(type = FieldType.Text),
+        otherFields = [
+            InnerField(
+                suffix = "partial",
+                type = FieldType.Text,
+                analyzer = "partial_index",
+                searchAnalyzer = "partial_search"
+            )
+        ]
+    )
+    val authors: String,
+    @MultiField(
+        mainField = Field(type = FieldType.Text),
+        otherFields = [
+            InnerField(
+                suffix = "partial",
+                type = FieldType.Text,
+                analyzer = "partial_index",
+                searchAnalyzer = "partial_search"
+            )
+        ]
+    )
+    val theme: String,
+    @MultiField(
+        mainField = Field(type = FieldType.Text),
+        otherFields = [
+            InnerField(
+                suffix = "partial",
+                type = FieldType.Text,
+                analyzer = "partial_index",
+                searchAnalyzer = "partial_search"
+            )
+        ]
+    )
+    val published: String,
+    @Field(type = FieldType.Keyword)
+    val link: String? = null
+)

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/SearchChunkDocumentRepository.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/search/elasticsearch/SearchChunkDocumentRepository.kt
@@ -1,0 +1,5 @@
+package com.example.poprogknowledgebaseback.adapters.outbound.search.elasticsearch
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
+
+interface SearchChunkDocumentRepository : ElasticsearchRepository<SearchChunkDocument, String>

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AiAssistantModels.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AiAssistantModels.kt
@@ -7,7 +7,8 @@ import java.util.UUID
 
 data class AssistantChatCommand(
     val chatId: UUID?,
-    val messages: List<AiChatMessage>
+    val messages: List<AiChatMessage>,
+    val documentRef: AssistantDocumentRef? = null
 )
 
 data class AssistantChatResult(
@@ -17,7 +18,26 @@ data class AssistantChatResult(
     val finishReason: String?,
     val promptTokens: Int?,
     val completionTokens: Int?,
-    val totalTokens: Int?
+    val totalTokens: Int?,
+    val documentHints: List<AssistantDocumentHint> = emptyList()
+)
+
+data class AssistantDocumentRef(
+    val sourceType: String?,
+    val sourceUuid: String?
+)
+
+data class AssistantDocumentHint(
+    val sourceType: String,
+    val sourceUuid: String?,
+    val scoreHint: Int,
+    val groupTitle: String,
+    val groupHash: String?,
+    val authors: String,
+    val theme: String,
+    val published: String,
+    val link: String?,
+    val snippet: String
 )
 
 data class ChatHistoryResult(

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AiAssistantService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AiAssistantService.kt
@@ -8,6 +8,7 @@ import com.example.poprogknowledgebaseback.domain.assistant.ChatConversationNotF
 import com.example.poprogknowledgebaseback.domain.assistant.StoredChatMessage
 import com.example.poprogknowledgebaseback.domain.assistant.port.AiAssistantPort
 import com.example.poprogknowledgebaseback.domain.assistant.port.ChatConversationPersistencePort
+import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
 import java.time.Clock
 import java.util.UUID
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -19,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional
 class AiAssistantService(
     private val aiAssistantPort: AiAssistantPort,
     private val chatConversationPersistencePort: ChatConversationPersistencePort,
+    private val documentQuestionResolver: DocumentQuestionResolver,
+    private val contextPromptBuilder: AssistantContextPromptBuilder,
     private val clock: Clock
 ) : AiAssistantUseCase {
 
@@ -40,7 +43,18 @@ class AiAssistantService(
         val history = chatConversationPersistencePort.findMessagesByChatIdOrderByCreatedAtAscIdAsc(conversation.id)
             .map { AiChatMessage(role = it.role, content = it.content) }
 
-        val assistantResponse = aiAssistantPort.complete(history + command.messages)
+        val documentContext = buildDocumentContext(command)
+        val documentHints = documentContext.hints
+        val systemPrompt = documentContext.systemPrompt
+        val messageList = if (systemPrompt.isBlank()) {
+            history + command.messages
+        } else {
+            listOf(
+                AiChatMessage(role = AiChatMessageRole.SYSTEM, content = systemPrompt)
+            ) + history + command.messages
+        }
+
+        val assistantResponse = aiAssistantPort.complete(messageList)
         persistConversationMessages(conversation.id, command.messages, assistantResponse)
 
         return AssistantChatResult(
@@ -50,8 +64,119 @@ class AiAssistantService(
             finishReason = assistantResponse.finishReason,
             promptTokens = assistantResponse.promptTokens,
             completionTokens = assistantResponse.completionTokens,
-            totalTokens = assistantResponse.totalTokens
+            totalTokens = assistantResponse.totalTokens,
+            documentHints = documentHints.map { it.toHint() }
         )
+    }
+
+    private fun buildDocumentContext(command: AssistantChatCommand): DocumentContext {
+        val userMessage = command.messages.lastOrNull { it.role == AiChatMessageRole.USER }?.content?.trim().orEmpty()
+        if (userMessage.isBlank()) {
+            return DocumentContext(emptyList(), "")
+        }
+
+        val ref = command.documentRef
+        val preferredType = ref?.sourceType?.let { sourceType ->
+            SearchSourceType.values().firstOrNull { it.name.equals(sourceType, ignoreCase = true) }
+        }
+        val explicitUuid = ref?.sourceUuid
+            ?.let { runCatching { UUID.fromString(it.trim()) }.getOrNull() }
+
+        val uuidsFromMessages = if (explicitUuid == null) {
+            documentQuestionResolver.extractUuids(command.messages.map { it.content })
+        } else {
+            emptyList()
+        }
+        val questionForSearch = sanitizeQuestion(userMessage, listOfNotNull(explicitUuid) + uuidsFromMessages)
+
+        val candidateUuids = listOfNotNull(explicitUuid) + uuidsFromMessages
+        if (candidateUuids.isNotEmpty()) {
+            val candidates = candidateUuids.flatMap { sourceUuid ->
+                documentQuestionResolver.resolveCandidatesByUuid(sourceUuid, preferredType)
+            }.distinctBy { Triple(it.sourceType, it.sourceId, it.sourceUuid) }
+
+            if (candidates.isNotEmpty()) {
+                val matches = candidates.mapNotNull { candidate ->
+                    val chunks = documentQuestionResolver.resolveChunksForDocument(
+                        question = questionForSearch,
+                        sourceType = candidate.sourceType,
+                        sourceId = candidate.sourceId
+                    )
+                    if (chunks.isEmpty()) {
+                        null
+                    } else {
+                        buildDocumentSearchResult(candidate, chunks)
+                    }
+                }
+
+                if (matches.isNotEmpty()) {
+                    val systemPrompt = contextPromptBuilder.buildSystemPrompt(matches)
+                    return DocumentContext(matches, systemPrompt)
+                }
+            }
+        }
+
+        val hints = documentQuestionResolver.resolveBestDocuments(questionForSearch)
+        if (hints.isEmpty()) {
+            return DocumentContext(emptyList(), "")
+        }
+        val systemPrompt = contextPromptBuilder.buildSystemPrompt(hints)
+        return DocumentContext(hints, systemPrompt)
+    }
+
+    private fun DocumentSearchResult.toHint() = AssistantDocumentHint(
+        sourceType = sourceType.name.lowercase(),
+        sourceUuid = sourceUuid,
+        scoreHint = scoreHint,
+        groupTitle = groupTitle,
+        groupHash = groupHash,
+        authors = authors,
+        theme = theme,
+        published = published,
+        link = link,
+        snippet = snippet
+    )
+
+    private data class DocumentContext(
+        val hints: List<DocumentSearchResult>,
+        val systemPrompt: String
+    )
+
+    private fun buildDocumentSearchResult(
+        candidate: DocumentCandidate,
+        chunks: List<com.example.poprogknowledgebaseback.domain.search.SearchChunk>
+    ): DocumentSearchResult {
+        val first = chunks.first()
+        val snippet = chunks.joinToString(" ") { it.content }
+            .replace(Regex("\\s+"), " ")
+            .trim()
+            .let { text -> if (text.length > 320) text.take(320) + "…" else text }
+
+        return DocumentSearchResult(
+            sourceType = candidate.sourceType,
+            sourceId = candidate.sourceId,
+            sourceUuid = candidate.sourceUuid,
+            scoreHint = chunks.size,
+            groupTitle = first.groupTitle,
+            groupHash = first.groupHash,
+            authors = first.authors,
+            theme = first.theme,
+            published = first.published,
+            link = first.link,
+            snippet = snippet
+        )
+    }
+
+    private fun sanitizeQuestion(message: String, uuids: List<UUID>): String {
+        if (uuids.isEmpty()) {
+            return message
+        }
+        var sanitized = message
+        uuids.forEach { uuid ->
+            sanitized = sanitized.replace(uuid.toString(), " ", ignoreCase = true)
+        }
+        sanitized = sanitized.replace(Regex("\\s+"), " ").trim()
+        return if (sanitized.length >= 3) sanitized else message
     }
 
     private fun persistConversationMessages(

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AssistantContextPromptBuilder.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AssistantContextPromptBuilder.kt
@@ -1,0 +1,66 @@
+package com.example.poprogknowledgebaseback.application.assistant
+
+import com.example.poprogknowledgebaseback.domain.search.SearchChunk
+import org.springframework.stereotype.Component
+
+@Component
+class AssistantContextPromptBuilder {
+
+    fun buildSystemPrompt(matches: List<DocumentSearchResult>): String {
+        if (matches.isEmpty()) {
+            return ""
+        }
+
+        val header = "Ты — ассистент по научным публикациям и студенческим работам. " +
+            "Отвечай строго на основе предоставленных фрагментов документов. " +
+            "Если в фрагментах нет ответа, скажи, что данных недостаточно."
+
+        val context = matches.joinToString("\n\n") { match ->
+            buildString {
+                append("Документ: ")
+                append(match.theme)
+                append(". Авторы: ")
+                append(match.authors)
+                append(". Источник: ")
+                append(match.published)
+                if (!match.link.isNullOrBlank()) {
+                    append(". Ссылка: ")
+                    append(match.link)
+                }
+                append("\nФрагмент: ")
+                append(match.snippet)
+            }
+        }
+
+        return header + "\n\n" + context
+    }
+
+    fun buildSystemPromptWithChunks(matches: List<SearchChunk>): String {
+        if (matches.isEmpty()) {
+            return ""
+        }
+
+        val header = "Ты — ассистент по научным публикациям и студенческим работам. " +
+            "Отвечай строго на основе предоставленных фрагментов документов. " +
+            "Если в фрагментах нет ответа, скажи, что данных недостаточно."
+
+        val context = matches.joinToString("\n\n") { match ->
+            buildString {
+                append("Документ: ")
+                append(match.theme)
+                append(". Авторы: ")
+                append(match.authors)
+                append(". Источник: ")
+                append(match.published)
+                if (!match.link.isNullOrBlank()) {
+                    append(". Ссылка: ")
+                    append(match.link)
+                }
+                append("\nФрагмент: ")
+                append(match.content)
+            }
+        }
+
+        return header + "\n\n" + context
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/DocumentQuestionResolver.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/DocumentQuestionResolver.kt
@@ -1,0 +1,74 @@
+package com.example.poprogknowledgebaseback.application.assistant
+
+import com.example.poprogknowledgebaseback.application.search.SearchChunkUseCase
+import com.example.poprogknowledgebaseback.domain.search.SearchChunk
+import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
+import org.springframework.stereotype.Component
+
+@Component
+class DocumentQuestionResolver(
+    private val searchChunkUseCase: SearchChunkUseCase
+) {
+
+    companion object {
+        private const val MAX_MATCHES = 6
+        private const val MAX_RESULTS = 3
+    }
+
+    fun resolveBestDocuments(question: String): List<DocumentSearchResult> {
+        val matches = searchChunkUseCase.search(question, limit = MAX_MATCHES)
+        if (matches.isEmpty()) {
+            return emptyList()
+        }
+
+        val grouped = matches.groupBy { it.sourceType to it.sourceId }
+        val scored = grouped.map { (key, chunks) ->
+            val first = chunks.minByOrNull { it.chunkIndex } ?: return@map null
+            DocumentSearchResult(
+                sourceType = key.first,
+                sourceId = key.second,
+                scoreHint = chunks.size,
+                groupTitle = first.groupTitle,
+                groupHash = first.groupHash,
+                authors = first.authors,
+                theme = first.theme,
+                published = first.published,
+                link = first.link,
+                snippet = buildSnippet(question, first)
+            )
+        }.filterNotNull()
+
+        return scored.sortedWith(
+            compareByDescending<DocumentSearchResult> { it.scoreHint }
+                .thenBy { it.sourceType.name }
+                .thenBy { it.sourceId }
+        ).take(MAX_RESULTS)
+    }
+
+    fun resolveChunksForDocument(
+        question: String,
+        sourceType: SearchSourceType,
+        sourceId: Long
+    ): List<SearchChunk> =
+        searchChunkUseCase.search(question, limit = MAX_MATCHES, sourceType = sourceType, sourceId = sourceId)
+
+    private fun buildSnippet(question: String, chunk: SearchChunk): String {
+        val normalized = chunk.content.replace(Regex("\\s+"), " ").trim()
+        if (normalized.length <= 320) {
+            return normalized
+        }
+
+        val lower = normalized.lowercase()
+        val queryLower = question.lowercase()
+        val idx = lower.indexOf(queryLower)
+        if (idx < 0) {
+            return normalized.take(320) + "…"
+        }
+
+        val start = (idx - 120).coerceAtLeast(0)
+        val end = (idx + 180).coerceAtMost(normalized.length)
+        val prefix = if (start > 0) "…" else ""
+        val suffix = if (end < normalized.length) "…" else ""
+        return prefix + normalized.substring(start, end).trim() + suffix
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/DocumentQuestionResolver.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/DocumentQuestionResolver.kt
@@ -1,13 +1,18 @@
 package com.example.poprogknowledgebaseback.application.assistant
 
 import com.example.poprogknowledgebaseback.application.search.SearchChunkUseCase
+import com.example.poprogknowledgebaseback.domain.publication.port.PublicationPersistencePort
 import com.example.poprogknowledgebaseback.domain.search.SearchChunk
 import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
+import com.example.poprogknowledgebaseback.domain.studentwork.port.StudentWorkPersistencePort
+import java.util.UUID
 import org.springframework.stereotype.Component
 
 @Component
 class DocumentQuestionResolver(
-    private val searchChunkUseCase: SearchChunkUseCase
+    private val searchChunkUseCase: SearchChunkUseCase,
+    private val publicationPersistencePort: PublicationPersistencePort,
+    private val studentWorkPersistencePort: StudentWorkPersistencePort
 ) {
 
     companion object {
@@ -27,6 +32,7 @@ class DocumentQuestionResolver(
             DocumentSearchResult(
                 sourceType = key.first,
                 sourceId = key.second,
+                sourceUuid = extractUuid(first.link),
                 scoreHint = chunks.size,
                 groupTitle = first.groupTitle,
                 groupHash = first.groupHash,
@@ -45,12 +51,77 @@ class DocumentQuestionResolver(
         ).take(MAX_RESULTS)
     }
 
+    fun resolveCandidatesByUuid(
+        sourceUuid: UUID,
+        preferredType: SearchSourceType?
+    ): List<DocumentCandidate> {
+        val uuidString = sourceUuid.toString()
+        val publicationCandidates = if (preferredType == null || preferredType == SearchSourceType.PUBLICATION) {
+            publicationPersistencePort.findAllOrderByYearDescIdAsc()
+                .mapNotNull { publication ->
+                    val publicationId = publication.id ?: return@mapNotNull null
+                    val linkUuid = extractUuid(publication.link) ?: return@mapNotNull null
+                    if (!linkUuid.equals(uuidString, ignoreCase = true)) {
+                        return@mapNotNull null
+                    }
+                    DocumentCandidate(
+                        sourceType = SearchSourceType.PUBLICATION,
+                        sourceId = publicationId,
+                        sourceUuid = linkUuid
+                    )
+                }
+        } else {
+            emptyList()
+        }
+
+        val studentWorkCandidates = if (preferredType == null || preferredType == SearchSourceType.STUDENT_WORK) {
+            studentWorkPersistencePort.findAllOrdered()
+                .mapNotNull { studentWork ->
+                    val studentWorkId = studentWork.id ?: return@mapNotNull null
+                    val linkUuid = extractUuid(studentWork.documentLink) ?: return@mapNotNull null
+                    if (!linkUuid.equals(uuidString, ignoreCase = true)) {
+                        return@mapNotNull null
+                    }
+                    DocumentCandidate(
+                        sourceType = SearchSourceType.STUDENT_WORK,
+                        sourceId = studentWorkId,
+                        sourceUuid = linkUuid
+                    )
+                }
+        } else {
+            emptyList()
+        }
+
+        return publicationCandidates + studentWorkCandidates
+    }
+
     fun resolveChunksForDocument(
         question: String,
         sourceType: SearchSourceType,
         sourceId: Long
-    ): List<SearchChunk> =
-        searchChunkUseCase.search(question, limit = MAX_MATCHES, sourceType = sourceType, sourceId = sourceId)
+    ): List<SearchChunk> {
+        val matches = searchChunkUseCase.search(question, limit = MAX_MATCHES, sourceType = sourceType, sourceId = sourceId)
+        if (matches.isNotEmpty()) {
+            return matches
+        }
+        return searchChunkUseCase.findBySource(sourceType = sourceType, sourceId = sourceId, limit = MAX_MATCHES)
+    }
+
+    fun extractUuids(messages: List<String>): List<UUID> {
+        val pattern = Regex("\\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\\b")
+        return messages
+            .flatMap { message -> pattern.findAll(message).map { it.value }.toList() }
+            .mapNotNull { uuidString -> runCatching { UUID.fromString(uuidString) }.getOrNull() }
+            .distinct()
+    }
+
+    fun extractUuid(link: String?): String? {
+        if (link.isNullOrBlank()) {
+            return null
+        }
+        val pattern = Regex("[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}")
+        return pattern.find(link)?.value?.lowercase()
+    }
 
     private fun buildSnippet(question: String, chunk: SearchChunk): String {
         val normalized = chunk.content.replace(Regex("\\s+"), " ").trim()
@@ -72,3 +143,9 @@ class DocumentQuestionResolver(
         return prefix + normalized.substring(start, end).trim() + suffix
     }
 }
+
+data class DocumentCandidate(
+    val sourceType: SearchSourceType,
+    val sourceId: Long,
+    val sourceUuid: String
+)

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/DocumentSearchResult.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/DocumentSearchResult.kt
@@ -5,6 +5,7 @@ import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
 data class DocumentSearchResult(
     val sourceType: SearchSourceType,
     val sourceId: Long,
+    val sourceUuid: String?,
     val scoreHint: Int,
     val groupTitle: String,
     val groupHash: String?,

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/DocumentSearchResult.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/DocumentSearchResult.kt
@@ -1,0 +1,16 @@
+package com.example.poprogknowledgebaseback.application.assistant
+
+import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
+
+data class DocumentSearchResult(
+    val sourceType: SearchSourceType,
+    val sourceId: Long,
+    val scoreHint: Int,
+    val groupTitle: String,
+    val groupHash: String?,
+    val authors: String,
+    val theme: String,
+    val published: String,
+    val link: String?,
+    val snippet: String
+)

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchChunkIndexingService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchChunkIndexingService.kt
@@ -1,0 +1,107 @@
+package com.example.poprogknowledgebaseback.application.search
+
+import com.example.poprogknowledgebaseback.domain.publication.Publication
+import com.example.poprogknowledgebaseback.domain.search.SearchChunk
+import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
+import com.example.poprogknowledgebaseback.domain.search.port.SearchChunkIndexPort
+import com.example.poprogknowledgebaseback.domain.studentwork.StudentWork
+import org.springframework.stereotype.Service
+
+@Service
+class SearchChunkIndexingService(
+    private val searchChunkIndexPort: SearchChunkIndexPort,
+    private val textChunker: TextChunker
+) {
+
+    fun reindex(publications: List<Publication>, studentWorks: List<StudentWork>) {
+        val chunks = publications.flatMap { publication ->
+            chunksForPublication(publication)
+        } + studentWorks.flatMap { studentWork ->
+            chunksForStudentWork(studentWork)
+        }
+
+        searchChunkIndexPort.replaceAll(chunks)
+    }
+
+    fun indexPublication(publication: Publication) {
+        val publicationId = publication.id ?: return
+        searchChunkIndexPort.deleteBySource(SearchSourceType.PUBLICATION, publicationId)
+
+        val chunks = chunksForPublication(publication)
+        if (chunks.isNotEmpty()) {
+            searchChunkIndexPort.index(chunks)
+        }
+    }
+
+    fun indexStudentWork(studentWork: StudentWork) {
+        val workId = studentWork.id ?: return
+        searchChunkIndexPort.deleteBySource(SearchSourceType.STUDENT_WORK, workId)
+
+        val chunks = chunksForStudentWork(studentWork)
+        if (chunks.isNotEmpty()) {
+            searchChunkIndexPort.index(chunks)
+        }
+    }
+
+    fun deletePublication(id: Long) {
+        searchChunkIndexPort.deleteBySource(SearchSourceType.PUBLICATION, id)
+    }
+
+    fun deleteStudentWork(id: Long) {
+        searchChunkIndexPort.deleteBySource(SearchSourceType.STUDENT_WORK, id)
+    }
+
+    private fun chunksForPublication(publication: Publication): List<SearchChunk> {
+        val publicationId = publication.id ?: return emptyList()
+        val pdfText = publication.pdfText?.trim().orEmpty()
+        if (pdfText.isBlank()) {
+            return emptyList()
+        }
+
+        return textChunker.chunk(pdfText).mapIndexed { index, chunk ->
+            SearchChunk(
+                id = chunkId(SearchSourceType.PUBLICATION, publicationId, index),
+                sourceType = SearchSourceType.PUBLICATION,
+                sourceId = publicationId,
+                groupTitle = publication.year.toString(),
+                groupHash = null,
+                authors = publication.authors,
+                theme = publication.theme,
+                published = publication.published,
+                link = publication.link.ifBlank { null },
+                chunkIndex = index,
+                content = chunk
+            )
+        }
+    }
+
+    private fun chunksForStudentWork(studentWork: StudentWork): List<SearchChunk> {
+        val workId = studentWork.id ?: return emptyList()
+        val pdfText = studentWork.pdfText?.trim().orEmpty()
+        if (pdfText.isBlank()) {
+            return emptyList()
+        }
+
+        return textChunker.chunk(pdfText).mapIndexed { index, chunk ->
+            SearchChunk(
+                id = chunkId(SearchSourceType.STUDENT_WORK, workId, index),
+                sourceType = SearchSourceType.STUDENT_WORK,
+                sourceId = workId,
+                groupTitle = studentWork.projectTypeTitle,
+                groupHash = studentWork.projectTypeHash,
+                authors = studentWork.authors,
+                theme = studentWork.theme,
+                published = studentWork.published,
+                link = studentWork.documentLink,
+                chunkIndex = index,
+                content = chunk
+            )
+        }
+    }
+
+    private fun chunkId(type: SearchSourceType, id: Long, index: Int): String =
+        when (type) {
+            SearchSourceType.PUBLICATION -> "publication-$id-chunk-$index"
+            SearchSourceType.STUDENT_WORK -> "student-work-$id-chunk-$index"
+        }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchChunkService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchChunkService.kt
@@ -1,0 +1,30 @@
+package com.example.poprogknowledgebaseback.application.search
+
+import com.example.poprogknowledgebaseback.domain.search.SearchChunk
+import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
+import com.example.poprogknowledgebaseback.domain.search.port.SearchChunkIndexPort
+import org.springframework.stereotype.Service
+
+@Service
+class SearchChunkService(
+    private val searchChunkIndexPort: SearchChunkIndexPort
+) : SearchChunkUseCase {
+
+    companion object {
+        private const val MIN_QUERY_LENGTH = 3
+    }
+
+    override fun search(
+        query: String,
+        limit: Int,
+        sourceType: SearchSourceType?,
+        sourceId: Long?
+    ): List<SearchChunk> {
+        val trimmed = query.trim()
+        if (trimmed.length < MIN_QUERY_LENGTH) {
+            return emptyList()
+        }
+
+        return searchChunkIndexPort.search(trimmed, limit, sourceType, sourceId)
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchChunkService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchChunkService.kt
@@ -14,6 +14,9 @@ class SearchChunkService(
         private const val MIN_QUERY_LENGTH = 3
     }
 
+    override fun findBySource(sourceType: SearchSourceType, sourceId: Long, limit: Int): List<SearchChunk> =
+        searchChunkIndexPort.findBySource(sourceType, sourceId, limit)
+
     override fun search(
         query: String,
         limit: Int,

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchChunkUseCase.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchChunkUseCase.kt
@@ -1,0 +1,13 @@
+package com.example.poprogknowledgebaseback.application.search
+
+import com.example.poprogknowledgebaseback.domain.search.SearchChunk
+import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
+
+interface SearchChunkUseCase {
+    fun search(
+        query: String,
+        limit: Int = 5,
+        sourceType: SearchSourceType? = null,
+        sourceId: Long? = null
+    ): List<SearchChunk>
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchChunkUseCase.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchChunkUseCase.kt
@@ -4,6 +4,8 @@ import com.example.poprogknowledgebaseback.domain.search.SearchChunk
 import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
 
 interface SearchChunkUseCase {
+    fun findBySource(sourceType: SearchSourceType, sourceId: Long, limit: Int = 5): List<SearchChunk>
+
     fun search(
         query: String,
         limit: Int = 5,

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/SearchService.kt
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service
 @Service
 class SearchService(
     private val searchIndexPort: SearchIndexPort,
+    private val searchChunkIndexingService: SearchChunkIndexingService,
     private val publicationPersistencePort: PublicationPersistencePort,
     private val studentWorkPersistencePort: StudentWorkPersistencePort,
     private val fileStoragePathResolver: FileStoragePathResolver,
@@ -27,11 +28,19 @@ class SearchService(
 
     @PostConstruct
     override fun reindex() {
-        val publicationItems = publicationPersistencePort.findAllOrderByYearDescIdAsc().map { publication ->
+        val publications = publicationPersistencePort.findAllOrderByYearDescIdAsc()
+        val studentWorks = studentWorkPersistencePort.findAllOrdered()
+
+        val publicationPrepared = publications.map { publication ->
             val pdfText = resolvePdfText(publication.pdfText, publication.link) { extracted ->
                 publicationPersistencePort.save(publication.copy(pdfText = extracted))
             }
-            SearchItem(
+            val updatedPublication = if (pdfText.isNullOrBlank() || pdfText == publication.pdfText) {
+                publication
+            } else {
+                publication.copy(pdfText = pdfText)
+            }
+            val item = SearchItem(
                 id = searchId(SearchSourceType.PUBLICATION, publication.id),
                 sourceType = SearchSourceType.PUBLICATION,
                 sourceId = publication.id ?: error("Publication id is missing"),
@@ -43,13 +52,19 @@ class SearchService(
                 link = publication.link.ifBlank { null },
                 pdfText = pdfText
             )
+            item to updatedPublication
         }
 
-        val studentWorkItems = studentWorkPersistencePort.findAllOrdered().map { studentWork ->
+        val studentWorkPrepared = studentWorks.map { studentWork ->
             val pdfText = resolvePdfText(studentWork.pdfText, studentWork.documentLink) { extracted ->
                 studentWorkPersistencePort.save(studentWork.copy(pdfText = extracted))
             }
-            SearchItem(
+            val updatedWork = if (pdfText.isNullOrBlank() || pdfText == studentWork.pdfText) {
+                studentWork
+            } else {
+                studentWork.copy(pdfText = pdfText)
+            }
+            val item = SearchItem(
                 id = searchId(SearchSourceType.STUDENT_WORK, studentWork.id),
                 sourceType = SearchSourceType.STUDENT_WORK,
                 sourceId = studentWork.id ?: error("Student work id is missing"),
@@ -61,9 +76,16 @@ class SearchService(
                 link = studentWork.documentLink,
                 pdfText = pdfText
             )
+            item to updatedWork
         }
 
-        searchIndexPort.replaceAll(publicationItems + studentWorkItems)
+        searchIndexPort.replaceAll(
+            publicationPrepared.map { it.first } + studentWorkPrepared.map { it.first }
+        )
+        searchChunkIndexingService.reindex(
+            publicationPrepared.map { it.second },
+            studentWorkPrepared.map { it.second }
+        )
     }
 
     override fun search(query: String, limit: Int): List<SearchResult> =
@@ -87,18 +109,22 @@ class SearchService(
 
     override fun indexPublication(publication: Publication) {
         searchIndexPort.index(publication.toSearchItem())
+        searchChunkIndexingService.indexPublication(publication)
     }
 
     override fun indexStudentWork(studentWork: StudentWork) {
         searchIndexPort.index(studentWork.toSearchItem())
+        searchChunkIndexingService.indexStudentWork(studentWork)
     }
 
     override fun removePublication(id: Long) {
         searchIndexPort.delete(searchId(SearchSourceType.PUBLICATION, id))
+        searchChunkIndexingService.deletePublication(id)
     }
 
     override fun removeStudentWork(id: Long) {
         searchIndexPort.delete(searchId(SearchSourceType.STUDENT_WORK, id))
+        searchChunkIndexingService.deleteStudentWork(id)
     }
 
     private fun Publication.toSearchItem() = SearchItem(

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/TextChunker.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/search/TextChunker.kt
@@ -1,0 +1,47 @@
+package com.example.poprogknowledgebaseback.application.search
+
+import org.springframework.stereotype.Component
+
+@Component
+class TextChunker {
+
+    companion object {
+        private const val MAX_CHUNK_CHARS = 1500
+        private const val OVERLAP_CHARS = 200
+        private const val MAX_CHUNKS = 400
+    }
+
+    fun chunk(text: String): List<String> {
+        val normalized = text.replace(Regex("\\s+"), " ").trim()
+        if (normalized.isBlank()) {
+            return emptyList()
+        }
+
+        val chunks = mutableListOf<String>()
+        var start = 0
+        while (start < normalized.length && chunks.size < MAX_CHUNKS) {
+            val maxEnd = minOf(start + MAX_CHUNK_CHARS, normalized.length)
+            var end = maxEnd
+            if (end < normalized.length) {
+                val lastSpace = normalized.lastIndexOf(' ', maxEnd)
+                if (lastSpace > start + MAX_CHUNK_CHARS / 2) {
+                    end = lastSpace
+                }
+            }
+
+            val chunk = normalized.substring(start, end).trim()
+            if (chunk.isNotBlank()) {
+                chunks.add(chunk)
+            }
+
+            if (end >= normalized.length) {
+                break
+            }
+
+            val nextStart = end - OVERLAP_CHARS
+            start = if (nextStart <= start) end else nextStart
+        }
+
+        return chunks
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/domain/search/SearchChunk.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/domain/search/SearchChunk.kt
@@ -1,0 +1,15 @@
+package com.example.poprogknowledgebaseback.domain.search
+
+data class SearchChunk(
+    val id: String,
+    val sourceType: SearchSourceType,
+    val sourceId: Long,
+    val groupTitle: String,
+    val groupHash: String?,
+    val authors: String,
+    val theme: String,
+    val published: String,
+    val link: String?,
+    val chunkIndex: Int,
+    val content: String
+)

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/domain/search/port/SearchChunkIndexPort.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/domain/search/port/SearchChunkIndexPort.kt
@@ -1,0 +1,16 @@
+package com.example.poprogknowledgebaseback.domain.search.port
+
+import com.example.poprogknowledgebaseback.domain.search.SearchChunk
+import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
+
+interface SearchChunkIndexPort {
+    fun replaceAll(chunks: List<SearchChunk>)
+    fun index(chunks: List<SearchChunk>)
+    fun deleteBySource(sourceType: SearchSourceType, sourceId: Long)
+    fun search(
+        query: String,
+        limit: Int,
+        sourceType: SearchSourceType? = null,
+        sourceId: Long? = null
+    ): List<SearchChunk>
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/domain/search/port/SearchChunkIndexPort.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/domain/search/port/SearchChunkIndexPort.kt
@@ -7,6 +7,7 @@ interface SearchChunkIndexPort {
     fun replaceAll(chunks: List<SearchChunk>)
     fun index(chunks: List<SearchChunk>)
     fun deleteBySource(sourceType: SearchSourceType, sourceId: Long)
+    fun findBySource(sourceType: SearchSourceType, sourceId: Long, limit: Int): List<SearchChunk>
     fun search(
         query: String,
         limit: Int,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=poprog-knowledge-base-back
+spring.config.import=optional:file:.env[.properties]
 spring.datasource.url=${DB_URL:jdbc:postgresql://localhost:5432/poprog_kb}
 spring.datasource.username=${DB_USER:postgres}
 spring.datasource.password=${DB_PASSWORD:postgres}
@@ -9,6 +10,8 @@ spring.elasticsearch.uris=${ELASTICSEARCH_URIS:http://localhost:9200}
 app.search.enabled=${SEARCH_ENABLED:true}
 app.files.storage-dir=${FILES_STORAGE_DIR:storage}
 app.files.base-url=${FILES_BASE_URL:/files}
+spring.servlet.multipart.max-file-size=25MB
+spring.servlet.multipart.max-request-size=25MB
 app.gigachat.enabled=${GIGACHAT_ENABLED:false}
 app.gigachat.auth-url=${GIGACHAT_AUTH_URL:https://ngw.devices.sberbank.ru:9443}
 app.gigachat.api-url=${GIGACHAT_API_URL:https://gigachat.devices.sberbank.ru}


### PR DESCRIPTION
## Что сделано
- Переведен контракт /api/assistant/chat с `sourceId` на `sourceUuid`.
- Добавлен авто-парсинг UUID из текста сообщений, если `document.sourceUuid` не передан.
- Добавлен резолв UUID к документам публикаций и студенческих работ.
- Добавлен fallback: если текстовый матч по вопросу не найден, берутся чанки документа напрямую по найденному UUID.
- Обновлены OpenAPI и инструкция по GigaChat.
- Подняты multipart-лимиты до 25MB в application.properties.

## Проверка
- `./gradlew test --tests '*AiAssistantControllerIntegrationTest'` — успешно.
- Ручка `/api/assistant/chat` проверена с явным `sourceUuid` и UUID в тексте сообщения.

Closes #31
