### PR TITLE
Back: non-anonymous usefulness feedback + grouped IDs + CI

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,35 @@
+name: Backend CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: .
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Test
+        run: ./gradlew test --no-daemon
+
+      - name: Build
+        run: ./gradlew build --no-daemon -x test

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ kubectl apply -n poprog-dev -f deploy/base/secret.example.yaml
 - `PUT /api/student-works/{id}`
 - `DELETE /api/student-works/{id}`
 
+`GET`-ответы grouped для публикаций и студенческих работ теперь содержат `id` каждого элемента, чтобы фронтенд мог прокручивать к конкретному найденному результату поиска.
+
 ### Поиск
 
 - `GET /api/search?q=<query>&limit=20`
@@ -163,6 +165,18 @@ kubectl apply -n poprog-dev -f deploy/base/secret.example.yaml
 - `PUT /api/projects/menu/promos/{id}`
 - `DELETE /api/projects/menu/promos/{id}`
 - `POST /api/projects/menu/resources/upload`
+
+### Файлы
+
+- `GET /api/files/{path}`
+
+`GET /api/files/{path}` — публичная ручка получения PDF-файлов по относительному пути в storage (например, `publications/<file>.pdf` или `student-works/<file>.pdf`). При успехе файл отдается с `Content-Disposition: inline`, чтобы его можно было открыть в браузере.
+
+### Обратная связь
+
+- `POST /api/feedback/usefulness`
+
+`POST /api/feedback/usefulness` — публичная ручка для сохранения реакции пользователя о полезности сайта. Обязательные поля: `helpful`, `userName`, `userEmail`. Опциональные поля: `source`, `comment`. На backend также сохраняются `ipAddress` и `userAgent` из запроса.
 
 `GET /api/projects/menu` возвращает полную структуру hover-меню раздела "Проекты": секции, CTA, карточки направлений и промо-блоки.
 

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/PdfUploadValidator.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/PdfUploadValidator.kt
@@ -1,0 +1,22 @@
+package com.example.poprogknowledgebaseback.adapters.inbound.web
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.multipart.MultipartFile
+import org.springframework.web.server.ResponseStatusException
+
+private val pdfContentTypes = setOf(
+    "application/pdf",
+    "application/x-pdf"
+)
+
+fun requirePdfUpload(file: MultipartFile) {
+    val originalName = file.originalFilename?.trim().orEmpty().lowercase()
+    val contentType = file.contentType?.trim()?.lowercase().orEmpty()
+
+    val fileNameLooksPdf = originalName.endsWith(".pdf")
+    val contentTypeLooksPdf = contentType in pdfContentTypes
+
+    if (!fileNameLooksPdf && !contentTypeLooksPdf) {
+        throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Only PDF files are supported for upload")
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/feedback/SiteFeedbackController.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/feedback/SiteFeedbackController.kt
@@ -1,0 +1,60 @@
+package com.example.poprogknowledgebaseback.adapters.inbound.web.feedback
+
+import com.example.poprogknowledgebaseback.application.feedback.CreateSiteFeedbackCommand
+import com.example.poprogknowledgebaseback.application.feedback.SiteFeedbackService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/feedback")
+@Tag(name = "Обратная связь", description = "Сбор реакции пользователя о полезности сайта")
+class SiteFeedbackController(
+    private val siteFeedbackService: SiteFeedbackService
+) {
+
+    @PostMapping("/usefulness")
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "Сохранить реакцию пользователя о полезности сайта",
+        description = "Публичная ручка для сбора оценки полезности сайта и необязательного комментария."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "201",
+                description = "Реакция успешно сохранена",
+                content = [Content(schema = Schema(implementation = SiteFeedbackUsefulnessResponse::class))]
+            ),
+            ApiResponse(responseCode = "400", description = "Некорректные входные данные")
+        ]
+    )
+    fun saveUsefulness(
+        @Valid @RequestBody request: SiteFeedbackUsefulnessRequest,
+        servletRequest: HttpServletRequest
+    ): SiteFeedbackUsefulnessResponse {
+        val id = siteFeedbackService.create(
+            CreateSiteFeedbackCommand(
+                helpful = request.helpful,
+                userName = request.userName,
+                userEmail = request.userEmail,
+                userAgent = servletRequest.getHeader("User-Agent"),
+                ipAddress = servletRequest.remoteAddr,
+                source = request.source,
+                comment = request.comment
+            )
+        )
+        return SiteFeedbackUsefulnessResponse(id = id)
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/feedback/SiteFeedbackDto.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/feedback/SiteFeedbackDto.kt
@@ -1,0 +1,24 @@
+package com.example.poprogknowledgebaseback.adapters.inbound.web.feedback
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class SiteFeedbackUsefulnessRequest(
+    val helpful: Boolean,
+    @field:NotBlank
+    @field:Size(max = 255)
+    val userName: String,
+    @field:NotBlank
+    @field:Email
+    @field:Size(max = 254)
+    val userEmail: String,
+    @field:Size(max = 255)
+    val source: String? = null,
+    @field:Size(max = 2000)
+    val comment: String? = null
+)
+
+data class SiteFeedbackUsefulnessResponse(
+    val id: Long
+)

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/files/FileAccessController.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/files/FileAccessController.kt
@@ -1,0 +1,139 @@
+package com.example.poprogknowledgebaseback.adapters.inbound.web.files
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import java.nio.file.Files
+import java.nio.file.Path
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.io.UrlResource
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/files")
+@Tag(name = "Файлы", description = "Публичный просмотр PDF-файлов по пути из storage")
+class FileAccessController(
+    @Value("\${app.files.storage-dir}") private val storageDir: String
+) {
+
+    @GetMapping("/{*path}")
+    @Operation(
+        summary = "Получить PDF-файл по относительному пути",
+        description = "Публично возвращает PDF-файл из локального storage. Успешный ответ отдается как inline для просмотра в браузере."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "PDF-файл успешно найден и отдан",
+                content = [Content(mediaType = MediaType.APPLICATION_PDF_VALUE, schema = Schema(type = "string", format = "binary"))]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "Некорректный путь или неподдерживаемый тип файла",
+                content = [Content(mediaType = MediaType.TEXT_HTML_VALUE)]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "Файл не найден",
+                content = [Content(mediaType = MediaType.TEXT_HTML_VALUE)]
+            )
+        ]
+    )
+    fun getFile(@PathVariable path: String): ResponseEntity<*> {
+        val relativePath = normalizePath(path)
+            ?: return htmlError(
+                status = HttpStatus.BAD_REQUEST,
+                title = "Некорректный путь к файлу",
+                message = "Проверьте ссылку и повторите запрос."
+            )
+
+        if (!relativePath.lowercase().endsWith(".pdf")) {
+            return htmlError(
+                status = HttpStatus.BAD_REQUEST,
+                title = "Неподдерживаемый тип файла",
+                message = "Сервис поддерживает только PDF-файлы."
+            )
+        }
+
+        val storageRoot = Path.of(storageDir).toAbsolutePath().normalize()
+        val targetPath = storageRoot.resolve(relativePath).normalize()
+        if (!targetPath.startsWith(storageRoot)) {
+            return htmlError(
+                status = HttpStatus.BAD_REQUEST,
+                title = "Некорректный путь к файлу",
+                message = "Запрошенный путь содержит недопустимые сегменты."
+            )
+        }
+
+        if (!Files.exists(targetPath) || !Files.isRegularFile(targetPath)) {
+            return htmlError(
+                status = HttpStatus.NOT_FOUND,
+                title = "Файл не найден",
+                message = "Запрошенный PDF-файл отсутствует в хранилище."
+            )
+        }
+
+        val resource = UrlResource(targetPath.toUri())
+        val fileName = targetPath.fileName.toString()
+        return ResponseEntity
+            .ok()
+            .contentType(MediaType.APPLICATION_PDF)
+            .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"$fileName\"")
+            .body(resource)
+    }
+
+    private fun normalizePath(input: String): String? {
+        val normalized = input.trim().removePrefix("/").replace('\\', '/')
+        if (normalized.isBlank()) {
+            return null
+        }
+
+        val segments = normalized.split('/')
+        if (segments.any { it.isBlank() || it == "." || it == ".." }) {
+            return null
+        }
+
+        return normalized
+    }
+
+    private fun htmlError(status: HttpStatus, title: String, message: String): ResponseEntity<String> {
+        val body = """
+            <!doctype html>
+            <html lang="ru">
+            <head>
+              <meta charset="UTF-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+              <title>$title</title>
+              <style>
+                body { margin: 0; font-family: "Tilda Sans VF", sans-serif; background: #f7f7f8; color: #1a1a1a; }
+                main { max-width: 760px; margin: 64px auto; padding: 0 20px; }
+                h1 { margin: 0 0 12px; font-size: 34px; line-height: 1.1; }
+                p { margin: 0; font-size: 18px; line-height: 1.5; color: #3a3a3a; }
+              </style>
+            </head>
+            <body>
+              <main>
+                <h1>$title</h1>
+                <p>$message</p>
+              </main>
+            </body>
+            </html>
+        """.trimIndent()
+
+        return ResponseEntity
+            .status(status)
+            .contentType(MediaType.TEXT_HTML)
+            .body(body)
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/publication/PublicationController.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/publication/PublicationController.kt
@@ -1,5 +1,6 @@
 package com.example.poprogknowledgebaseback.adapters.inbound.web.publication
 
+import com.example.poprogknowledgebaseback.adapters.inbound.web.requirePdfUpload
 import com.example.poprogknowledgebaseback.application.files.FileStorageUseCase
 import com.example.poprogknowledgebaseback.application.publication.PublicationUseCase
 import com.example.poprogknowledgebaseback.application.publication.UpsertPublicationCommand
@@ -92,6 +93,7 @@ class PublicationController(
         @Valid @RequestPart("metadata") request: PublicationUploadRequest,
         @RequestPart("file") file: MultipartFile
     ): PublicationResponse {
+        requirePdfUpload(file)
         val storedFile = fileStorageUseCase.store("publications", file)
         return publicationUseCase.create(request.toCommand(storedFile.url)).toDto()
     }
@@ -162,6 +164,7 @@ class PublicationController(
         date = date,
         publications = publications.map {
             PublicationModelDto(
+                id = it.id,
                 authors = it.authors,
                 theme = it.theme,
                 published = it.published,

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/publication/PublicationDto.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/publication/PublicationDto.kt
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotBlank
 
 data class PublicationModelDto(
+    val id: Long,
     val authors: String,
     val theme: String,
     val published: String,

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/studentwork/StudentWorkController.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/studentwork/StudentWorkController.kt
@@ -1,5 +1,6 @@
 package com.example.poprogknowledgebaseback.adapters.inbound.web.studentwork
 
+import com.example.poprogknowledgebaseback.adapters.inbound.web.requirePdfUpload
 import com.example.poprogknowledgebaseback.application.files.FileStorageUseCase
 import com.example.poprogknowledgebaseback.application.studentwork.StudentWorkResult
 import com.example.poprogknowledgebaseback.application.studentwork.StudentWorkUseCase
@@ -94,6 +95,7 @@ class StudentWorkController(
         @Valid @RequestPart("metadata") request: StudentWorkUploadRequest,
         @RequestPart("file") file: MultipartFile
     ): StudentWorkResponse {
+        requirePdfUpload(file)
         val storedFile = fileStorageUseCase.store("student-works", file)
         return studentWorkUseCase.create(request.toCommand(storedFile.url)).toDto()
     }
@@ -166,6 +168,7 @@ class StudentWorkController(
         hash = hash,
         works = works.map {
             WorkModelDto(
+                id = it.id,
                 authors = it.authors,
                 theme = it.theme,
                 published = it.published

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/studentwork/StudentWorkDto.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/studentwork/StudentWorkDto.kt
@@ -3,6 +3,7 @@ package com.example.poprogknowledgebaseback.adapters.inbound.web.studentwork
 import jakarta.validation.constraints.NotBlank
 
 data class WorkModelDto(
+    val id: Long,
     val authors: String,
     val theme: String,
     val published: String

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/feedback/SiteFeedbackJpaEntity.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/feedback/SiteFeedbackJpaEntity.kt
@@ -1,0 +1,41 @@
+package com.example.poprogknowledgebaseback.adapters.outbound.persistence.feedback
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.OffsetDateTime
+
+@Entity
+@Table(name = "site_feedback")
+class SiteFeedbackJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(nullable = false)
+    var helpful: Boolean,
+
+    @Column
+    var source: String? = null,
+
+    @Column(columnDefinition = "text")
+    var comment: String? = null,
+
+    @Column(name = "user_name")
+    var userName: String? = null,
+
+    @Column(name = "user_email")
+    var userEmail: String? = null,
+
+    @Column(name = "user_agent")
+    var userAgent: String? = null,
+
+    @Column(name = "ip_address")
+    var ipAddress: String? = null,
+
+    @Column(name = "created_at", nullable = false)
+    var createdAt: OffsetDateTime = OffsetDateTime.now()
+)

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/feedback/SpringDataSiteFeedbackRepository.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/feedback/SpringDataSiteFeedbackRepository.kt
@@ -1,0 +1,5 @@
+package com.example.poprogknowledgebaseback.adapters.outbound.persistence.feedback
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SpringDataSiteFeedbackRepository : JpaRepository<SiteFeedbackJpaEntity, Long>

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/feedback/SiteFeedbackService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/feedback/SiteFeedbackService.kt
@@ -1,0 +1,42 @@
+package com.example.poprogknowledgebaseback.application.feedback
+
+import com.example.poprogknowledgebaseback.adapters.outbound.persistence.feedback.SiteFeedbackJpaEntity
+import com.example.poprogknowledgebaseback.adapters.outbound.persistence.feedback.SpringDataSiteFeedbackRepository
+import java.time.Clock
+import java.time.OffsetDateTime
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+data class CreateSiteFeedbackCommand(
+    val helpful: Boolean,
+    val userName: String,
+    val userEmail: String,
+    val userAgent: String?,
+    val ipAddress: String?,
+    val source: String?,
+    val comment: String?
+)
+
+@Service
+class SiteFeedbackService(
+    private val repository: SpringDataSiteFeedbackRepository,
+    private val clock: Clock
+) {
+
+    @Transactional
+    fun create(command: CreateSiteFeedbackCommand): Long {
+        val saved = repository.save(
+            SiteFeedbackJpaEntity(
+                helpful = command.helpful,
+                userName = command.userName.trim(),
+                userEmail = command.userEmail.trim(),
+                userAgent = command.userAgent?.trim()?.takeIf { it.isNotBlank() }?.take(512),
+                ipAddress = command.ipAddress?.trim()?.takeIf { it.isNotBlank() }?.take(64),
+                source = command.source?.trim()?.takeIf { it.isNotBlank() },
+                comment = command.comment?.trim()?.takeIf { it.isNotBlank() },
+                createdAt = OffsetDateTime.now(clock)
+            )
+        )
+        return saved.id ?: error("Site feedback id was not generated")
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/publication/PublicationService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/publication/PublicationService.kt
@@ -28,6 +28,7 @@ class PublicationService(
                     date = year.toString(),
                     publications = yearPublications.map { publication ->
                         PublicationModel(
+                            id = publication.id ?: error("Publication id is missing"),
                             authors = publication.authors,
                             theme = publication.theme,
                             published = publication.published,

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/studentwork/StudentWorkService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/studentwork/StudentWorkService.kt
@@ -31,6 +31,7 @@ class StudentWorkService(
                     hash = first.projectTypeHash,
                     works = groupedWorks.map {
                         WorkModel(
+                            id = it.id ?: error("Student work id is missing"),
                             authors = it.authors,
                             theme = it.theme,
                             published = it.published

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/domain/publication/GroupedPublications.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/domain/publication/GroupedPublications.kt
@@ -1,6 +1,7 @@
 package com.example.poprogknowledgebaseback.domain.publication
 
 data class PublicationModel(
+    val id: Long,
     val authors: String,
     val theme: String,
     val published: String,

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/domain/studentwork/GroupedWorks.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/domain/studentwork/GroupedWorks.kt
@@ -1,6 +1,7 @@
 package com.example.poprogknowledgebaseback.domain.studentwork
 
 data class WorkModel(
+    val id: Long,
     val authors: String,
     val theme: String,
     val published: String

--- a/src/main/resources/db/changelog/010-create-site-feedback-table.sql
+++ b/src/main/resources/db/changelog/010-create-site-feedback-table.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+
+--changeset codex:010-create-site-feedback-table
+CREATE TABLE site_feedback
+(
+    id          BIGSERIAL PRIMARY KEY,
+    helpful     BOOLEAN      NOT NULL,
+    source      VARCHAR(255),
+    comment     TEXT,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
+);

--- a/src/main/resources/db/changelog/011-add-identity-columns-to-site-feedback.sql
+++ b/src/main/resources/db/changelog/011-add-identity-columns-to-site-feedback.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+
+--changeset codex:011-add-identity-columns-to-site-feedback
+ALTER TABLE site_feedback
+    ADD COLUMN user_name VARCHAR(255),
+    ADD COLUMN user_email VARCHAR(254),
+    ADD COLUMN user_agent VARCHAR(512),
+    ADD COLUMN ip_address VARCHAR(64);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -17,3 +17,7 @@ databaseChangeLog:
       file: db/changelog/008-seed-project-menu.sql
   - include:
       file: db/changelog/009-add-pdf-text-columns.sql
+  - include:
+      file: db/changelog/010-create-site-feedback-table.sql
+  - include:
+      file: db/changelog/011-add-identity-columns-to-site-feedback.sql

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/OpenApiContractIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/OpenApiContractIntegrationTest.kt
@@ -47,6 +47,49 @@ class OpenApiContractIntegrationTest {
         assertTrue(paths.has("/api/student-works/grouped"))
         assertTrue(paths.has("/api/student-works/upload"))
         assertTrue(paths.has("/api/search"))
+        assertTrue(paths.has("/api/files/{path}"))
+        assertTrue(paths.has("/api/feedback/usefulness"))
+    }
+
+    @Test
+    fun `should mark admin mutation endpoints in openapi summaries`() {
+        val responseBody = mockMvc.perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val root = objectMapper.readTree(responseBody)
+        val paths = root["paths"]
+
+        val adminOperations = listOf(
+            "/api/publications" to "post",
+            "/api/publications/upload" to "post",
+            "/api/publications/{id}" to "put",
+            "/api/publications/{id}" to "delete",
+            "/api/student-works" to "post",
+            "/api/student-works/upload" to "post",
+            "/api/student-works/{id}" to "put",
+            "/api/student-works/{id}" to "delete",
+            "/api/projects/menu/sections" to "post",
+            "/api/projects/menu/sections/{id}" to "put",
+            "/api/projects/menu/sections/{id}" to "delete",
+            "/api/projects/menu/items" to "post",
+            "/api/projects/menu/items/{id}" to "put",
+            "/api/projects/menu/items/{id}" to "delete",
+            "/api/projects/menu/promos" to "post",
+            "/api/projects/menu/promos/{id}" to "put",
+            "/api/projects/menu/promos/{id}" to "delete",
+            "/api/projects/menu/resources/upload" to "post"
+        )
+
+        adminOperations.forEach { (path, method) ->
+            val summary = paths[path][method]["summary"].requiredText()
+            assertTrue(
+                summary.startsWith("[ADMIN]"),
+                "Operation $method $path must start with [ADMIN] in OpenAPI summary, but was: $summary"
+            )
+        }
     }
 
     companion object {

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/SiteFeedbackControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/SiteFeedbackControllerIntegrationTest.kt
@@ -1,0 +1,89 @@
+package com.example.poprogknowledgebaseback
+
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.ObjectMapper
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class SiteFeedbackControllerIntegrationTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `should save site usefulness feedback`() {
+        val payload =
+            """
+            {
+              "helpful": true,
+              "userName": "Egor Kuznecov",
+              "userEmail": "egor@example.com",
+              "source": "search-modal",
+              "comment": "Хорошо работает поиск"
+            }
+            """.trimIndent()
+
+        val responseBody = mockMvc.perform(
+            post("/api/feedback/usefulness")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+        )
+            .andExpect(status().isCreated)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val root = objectMapper.readTree(responseBody)
+        assertTrue(root["id"].asLong() > 0)
+    }
+
+    @Test
+    fun `should reject blank user name`() {
+        val payload =
+            """
+            {
+              "helpful": false,
+              "userName": " ",
+              "userEmail": "egor@example.com",
+              "source": "search-modal"
+            }
+            """.trimIndent()
+
+        mockMvc.perform(
+            post("/api/feedback/usefulness")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    companion object {
+        @Container
+        private val postgres = PostgreSQLContainer("postgres:18")
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerDataSource(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}


### PR DESCRIPTION
## Что сделано
- добавлена ручка `POST /api/feedback/usefulness` с неанонимной моделью (`userName`, `userEmail`)
- сохраняются `userAgent` и `ipAddress` из запроса
- добавлены миграции `010` и `011` для таблицы обратной связи
- grouped-ответы публикаций/работ теперь содержат `id` элемента для фронтового фокуса
- добавлен backend CI workflow в режиме build+test

## Issues
- Closes #34
- Closes #35
- Closes #32
- Relates #36
- Relates #37
- Relates #38
- Relates #39

## Проверка
- ./gradlew test --tests "*SiteFeedbackControllerIntegrationTest" --tests "*OpenApiContractIntegrationTest"
