### PR TITLE
[codex] Add backend reporting, metrics, and local assistant fallback

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,17 @@
 - `/api/account/chats`
 - `/api/account/favorites`
 - `/api/account/donations`
+- `/api/account/donations/export.csv`
+- `/api/account/donations/export.pdf`
 - `/api/donations` (публичный донат без авторизации)
+- `/api/admin/donations/kpi` (`[ADMIN]`)
+- `/api/admin/donations/events` (`[ADMIN]`, фильтры + пагинация)
+- `/api/admin/donations/export.csv` (`[ADMIN]`)
+- `/api/admin/donations/export.pdf` (`[ADMIN]`)
+- `/api/metrics/events`
+- `/api/metrics/reports/dau-wau`
+- `/api/metrics/reports/search-success`
+- `/api/metrics/reports/ctr`
 - `/api/market/apps`
 - `/api/market/categories`
 - `/api/search`

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/account/AccountDonationController.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/account/AccountDonationController.kt
@@ -15,13 +15,19 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import java.math.BigDecimal
+import java.time.OffsetDateTime
 import java.util.UUID
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
@@ -73,6 +79,34 @@ class AccountDonationController(
     fun getDonations(@CurrentUserParam currentUser: CurrentUser): List<AccountDonationResponse> =
         accountDonationService.getDonations(currentUser.subject)
             .map { it.toResponse() }
+
+    @GetMapping("/export.csv")
+    @Operation(summary = "Экспортировать историю пожертвований в CSV")
+    fun exportDonationsCsv(
+        @CurrentUserParam currentUser: CurrentUser,
+        @RequestParam(required = false) from: OffsetDateTime?,
+        @RequestParam(required = false) to: OffsetDateTime?
+    ): ResponseEntity<ByteArray> {
+        val payload = accountDonationService.exportDonationsCsv(currentUser.subject, from, to)
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.parseMediaType("text/csv; charset=utf-8")
+        headers.contentDisposition = ContentDisposition.attachment().filename("account-donations.csv").build()
+        return ResponseEntity(payload, headers, HttpStatus.OK)
+    }
+
+    @GetMapping("/export.pdf")
+    @Operation(summary = "Экспортировать историю пожертвований в PDF")
+    fun exportDonationsPdf(
+        @CurrentUserParam currentUser: CurrentUser,
+        @RequestParam(required = false) from: OffsetDateTime?,
+        @RequestParam(required = false) to: OffsetDateTime?
+    ): ResponseEntity<ByteArray> {
+        val payload = accountDonationService.exportDonationsPdf(currentUser.subject, from, to)
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_PDF
+        headers.contentDisposition = ContentDisposition.attachment().filename("account-donations.pdf").build()
+        return ResponseEntity(payload, headers, HttpStatus.OK)
+    }
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/donation/AdminDonationReportingController.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/donation/AdminDonationReportingController.kt
@@ -1,0 +1,111 @@
+package com.example.poprogknowledgebaseback.adapters.inbound.web.donation
+
+import com.example.poprogknowledgebaseback.adapters.inbound.web.auth.CurrentUser
+import com.example.poprogknowledgebaseback.adapters.inbound.web.auth.CurrentUserParam
+import com.example.poprogknowledgebaseback.application.account.AdminDonationReportingService
+import com.example.poprogknowledgebaseback.application.account.DonationEventPageResult
+import com.example.poprogknowledgebaseback.application.account.DonationKpiReportResult
+import com.example.poprogknowledgebaseback.application.account.DonationReportingFilters
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import java.time.OffsetDateTime
+import org.springframework.http.ContentDisposition
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.server.ResponseStatusException
+
+@RestController
+@RequestMapping("/api/admin/donations")
+@Tag(name = "Пожертвования", description = "Административная аналитика и экспорт пожертвований")
+class AdminDonationReportingController(
+    private val reportingService: AdminDonationReportingService
+) {
+
+    @GetMapping("/kpi")
+    @Operation(summary = "[ADMIN] Получить KPI по пожертвованиям")
+    fun getKpi(
+        @CurrentUserParam currentUser: CurrentUser,
+        @RequestParam(required = false) from: OffsetDateTime?,
+        @RequestParam(required = false) to: OffsetDateTime?
+    ): DonationKpiReportResult {
+        requireAdmin(currentUser)
+        return reportingService.getKpi(
+            DonationReportingFilters(
+                from = from,
+                to = to
+            )
+        )
+    }
+
+    @GetMapping("/events")
+    @Operation(summary = "[ADMIN] Получить события по пожертвованиям")
+    fun getEvents(
+        @CurrentUserParam currentUser: CurrentUser,
+        @RequestParam(required = false) from: OffsetDateTime?,
+        @RequestParam(required = false) to: OffsetDateTime?,
+        @RequestParam(required = false) status: String?,
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int
+    ): DonationEventPageResult {
+        requireAdmin(currentUser)
+        return reportingService.getEvents(
+            filters = DonationReportingFilters(from = from, to = to, status = status),
+            page = page,
+            size = size
+        )
+    }
+
+    @GetMapping("/export.csv")
+    @Operation(summary = "[ADMIN] Экспортировать события пожертвований в CSV")
+    fun exportCsv(
+        @CurrentUserParam currentUser: CurrentUser,
+        @RequestParam(required = false) from: OffsetDateTime?,
+        @RequestParam(required = false) to: OffsetDateTime?,
+        @RequestParam(required = false) status: String?,
+        @RequestParam(defaultValue = "2000") limit: Int
+    ): ResponseEntity<ByteArray> {
+        requireAdmin(currentUser)
+        val payload = reportingService.exportEventsCsv(
+            filters = DonationReportingFilters(from = from, to = to, status = status),
+            limit = limit
+        )
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.parseMediaType("text/csv; charset=utf-8")
+        headers.contentDisposition = ContentDisposition.attachment().filename("donations-events.csv").build()
+        return ResponseEntity(payload, headers, HttpStatus.OK)
+    }
+
+    @GetMapping("/export.pdf")
+    @Operation(summary = "[ADMIN] Экспортировать события пожертвований в PDF")
+    fun exportPdf(
+        @CurrentUserParam currentUser: CurrentUser,
+        @RequestParam(required = false) from: OffsetDateTime?,
+        @RequestParam(required = false) to: OffsetDateTime?,
+        @RequestParam(required = false) status: String?,
+        @RequestParam(defaultValue = "1000") limit: Int
+    ): ResponseEntity<ByteArray> {
+        requireAdmin(currentUser)
+        val payload = reportingService.exportEventsPdf(
+            filters = DonationReportingFilters(from = from, to = to, status = status),
+            limit = limit
+        )
+
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_PDF
+        headers.contentDisposition = ContentDisposition.attachment().filename("donations-events.pdf").build()
+        return ResponseEntity(payload, headers, HttpStatus.OK)
+    }
+
+    private fun requireAdmin(currentUser: CurrentUser) {
+        if (!currentUser.hasRole("ADMIN")) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Admin role is required")
+        }
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/metrics/ProductMetricsController.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/metrics/ProductMetricsController.kt
@@ -1,0 +1,91 @@
+package com.example.poprogknowledgebaseback.adapters.inbound.web.metrics
+
+import com.example.poprogknowledgebaseback.application.metrics.DauWauReportResult
+import com.example.poprogknowledgebaseback.application.metrics.ProductMetricEventCommand
+import com.example.poprogknowledgebaseback.application.metrics.ProductMetricsService
+import com.example.poprogknowledgebaseback.application.metrics.SearchSuccessReportResult
+import com.example.poprogknowledgebaseback.application.metrics.SourceTypeCtrReportResult
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import java.time.OffsetDateTime
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+data class ProductMetricEventRequest(
+    @field:NotBlank
+    @field:Size(max = 64)
+    val eventType: String,
+    @field:NotBlank
+    @field:Size(max = 255)
+    val route: String,
+    @field:Size(max = 2048)
+    val referrer: String? = null,
+    @field:NotBlank
+    @field:Size(max = 128)
+    val sessionId: String,
+    @field:Size(max = 128)
+    val userKey: String? = null,
+    val timestampClient: OffsetDateTime,
+    val payload: Map<String, Any?> = emptyMap()
+)
+
+data class ProductMetricAcceptedResponse(
+    val id: Long,
+    val status: String = "accepted"
+)
+
+@RestController
+@RequestMapping("/api/metrics")
+@Tag(name = "Продуктовые метрики", description = "Прием событий и продуктовые отчеты")
+class ProductMetricsController(
+    private val productMetricsService: ProductMetricsService
+) {
+
+    @PostMapping("/events")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @Operation(summary = "Принять событие продуктовой аналитики")
+    fun saveEvent(@Valid @RequestBody request: ProductMetricEventRequest): ProductMetricAcceptedResponse {
+        val id = productMetricsService.saveEvent(
+            ProductMetricEventCommand(
+                eventType = request.eventType,
+                route = request.route,
+                referrer = request.referrer,
+                sessionId = request.sessionId,
+                userKey = request.userKey,
+                timestampClient = request.timestampClient,
+                payload = request.payload
+            )
+        )
+        return ProductMetricAcceptedResponse(id = id)
+    }
+
+    @GetMapping("/reports/dau-wau")
+    @Operation(summary = "Получить отчет по ежедневной и недельной активности")
+    fun getDauWauReport(
+        @RequestParam(required = false) from: OffsetDateTime?,
+        @RequestParam(required = false) to: OffsetDateTime?
+    ): DauWauReportResult = productMetricsService.getDauWauReport(from, to)
+
+    @GetMapping("/reports/search-success")
+    @Operation(summary = "Получить отчет по успешности поисковых сессий")
+    fun getSearchSuccessReport(
+        @RequestParam(required = false) from: OffsetDateTime?,
+        @RequestParam(required = false) to: OffsetDateTime?
+    ): SearchSuccessReportResult = productMetricsService.getSearchSuccessReport(from, to)
+
+    @GetMapping("/reports/ctr")
+    @Operation(summary = "Получить отчет по кликам и показам по типам источников")
+    fun getCtrReport(
+        @RequestParam(required = false) from: OffsetDateTime?,
+        @RequestParam(required = false) to: OffsetDateTime?
+    ): SourceTypeCtrReportResult = productMetricsService.getCtrReport(from, to)
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/donation/SpringDataDonationPaymentRepository.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/donation/SpringDataDonationPaymentRepository.kt
@@ -7,4 +7,24 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface SpringDataDonationPaymentRepository : JpaRepository<DonationPaymentJpaEntity, UUID> {
     fun findAllByUserSubOrderByCreatedAtDesc(userSub: String): List<DonationPaymentJpaEntity>
     fun findByIdAndUserSub(id: UUID, userSub: String): Optional<DonationPaymentJpaEntity>
+    fun findAllByUserSubAndCreatedAtGreaterThanEqualOrderByCreatedAtDesc(
+        userSub: String,
+        from: java.time.OffsetDateTime
+    ): List<DonationPaymentJpaEntity>
+    fun findAllByUserSubAndCreatedAtLessThanEqualOrderByCreatedAtDesc(
+        userSub: String,
+        to: java.time.OffsetDateTime
+    ): List<DonationPaymentJpaEntity>
+    fun findAllByUserSubAndCreatedAtGreaterThanEqualAndCreatedAtLessThanEqualOrderByCreatedAtDesc(
+        userSub: String,
+        from: java.time.OffsetDateTime,
+        to: java.time.OffsetDateTime
+    ): List<DonationPaymentJpaEntity>
+    fun findAllByOrderByCreatedAtDesc(): List<DonationPaymentJpaEntity>
+    fun findAllByCreatedAtGreaterThanEqualOrderByCreatedAtDesc(from: java.time.OffsetDateTime): List<DonationPaymentJpaEntity>
+    fun findAllByCreatedAtLessThanEqualOrderByCreatedAtDesc(to: java.time.OffsetDateTime): List<DonationPaymentJpaEntity>
+    fun findAllByCreatedAtGreaterThanEqualAndCreatedAtLessThanEqualOrderByCreatedAtDesc(
+        from: java.time.OffsetDateTime,
+        to: java.time.OffsetDateTime
+    ): List<DonationPaymentJpaEntity>
 }

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/metrics/ProductMetricEventJpaEntity.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/metrics/ProductMetricEventJpaEntity.kt
@@ -1,0 +1,41 @@
+package com.example.poprogknowledgebaseback.adapters.outbound.persistence.metrics
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.OffsetDateTime
+
+@Entity
+@Table(name = "product_metric_event")
+class ProductMetricEventJpaEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "event_type", nullable = false, length = 64)
+    var eventType: String,
+
+    @Column(nullable = false, length = 255)
+    var route: String,
+
+    @Column(length = 2048)
+    var referrer: String? = null,
+
+    @Column(name = "session_id", nullable = false, length = 128)
+    var sessionId: String,
+
+    @Column(name = "user_key", nullable = false, length = 128)
+    var userKey: String,
+
+    @Column(name = "timestamp_client", nullable = false)
+    var timestampClient: OffsetDateTime,
+
+    @Column(name = "timestamp_server", nullable = false)
+    var timestampServer: OffsetDateTime,
+
+    @Column(name = "payload_json", nullable = false, columnDefinition = "TEXT")
+    var payloadJson: String
+)

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/metrics/SpringDataProductMetricEventRepository.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/metrics/SpringDataProductMetricEventRepository.kt
@@ -1,0 +1,11 @@
+package com.example.poprogknowledgebaseback.adapters.outbound.persistence.metrics
+
+import java.time.OffsetDateTime
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SpringDataProductMetricEventRepository : JpaRepository<ProductMetricEventJpaEntity, Long> {
+    fun findAllByTimestampServerGreaterThanEqualAndTimestampServerLessThanEqualOrderByTimestampServerAsc(
+        from: OffsetDateTime,
+        to: OffsetDateTime
+    ): List<ProductMetricEventJpaEntity>
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/account/AccountDonationService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/account/AccountDonationService.kt
@@ -2,10 +2,18 @@ package com.example.poprogknowledgebaseback.application.account
 
 import com.example.poprogknowledgebaseback.adapters.outbound.persistence.donation.DonationPaymentJpaEntity
 import com.example.poprogknowledgebaseback.adapters.outbound.persistence.donation.SpringDataDonationPaymentRepository
+import java.io.ByteArrayOutputStream
 import java.math.BigDecimal
+import java.math.RoundingMode
 import java.time.Clock
 import java.time.OffsetDateTime
 import java.util.UUID
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.PDPageContentStream
+import org.apache.pdfbox.pdmodel.common.PDRectangle
+import org.apache.pdfbox.pdmodel.font.PDType1Font
+import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -49,6 +57,78 @@ class AccountDonationService(
     fun getDonations(userSub: String): List<AccountDonationResult> =
         donationRepository.findAllByUserSubOrderByCreatedAtDesc(userSub)
             .map { it.toResult() }
+
+    @Transactional(readOnly = true)
+    fun exportDonationsCsv(userSub: String, from: OffsetDateTime?, to: OffsetDateTime?): ByteArray {
+        val donations = findByFilters(userSub, from, to)
+        auditLogger.info(
+            "Account donation export requested: format=CSV, userSub={}, from={}, to={}, count={}",
+            userSub,
+            from,
+            to,
+            donations.size
+        )
+
+        val header = listOf(
+            "id",
+            "amount",
+            "currency",
+            "status",
+            "source",
+            "message",
+            "providerPaymentId",
+            "returnUrl",
+            "createdAt",
+            "updatedAt",
+            "paidAt"
+        ).joinToString(",")
+        val rows = donations.joinToString("\n") { donation ->
+            listOf(
+                donation.id.toString(),
+                donation.amount.toMoney(),
+                donation.currency,
+                donation.status,
+                donation.source.orEmpty(),
+                donation.message.orEmpty(),
+                donation.providerPaymentId.orEmpty(),
+                donation.returnUrl,
+                donation.createdAt.toString(),
+                donation.updatedAt.toString(),
+                donation.paidAt?.toString().orEmpty()
+            ).joinToString(",") { escapeCsv(it) }
+        }
+        return "$header\n$rows\n".toByteArray(Charsets.UTF_8)
+    }
+
+    @Transactional(readOnly = true)
+    fun exportDonationsPdf(userSub: String, from: OffsetDateTime?, to: OffsetDateTime?): ByteArray {
+        val donations = findByFilters(userSub, from, to)
+        auditLogger.info(
+            "Account donation export requested: format=PDF, userSub={}, from={}, to={}, count={}",
+            userSub,
+            from,
+            to,
+            donations.size
+        )
+
+        val lines = mutableListOf("POPROG Account Donations Report", "")
+        donations.forEachIndexed { index, donation ->
+            lines += buildString {
+                append(index + 1)
+                append(". ")
+                append(donation.createdAt)
+                append(" | ")
+                append(donation.amount.toMoney())
+                append(" ")
+                append(donation.currency)
+                append(" | ")
+                append(donation.status)
+                append(" | ")
+                append(donation.source ?: "direct")
+            }.take(160)
+        }
+        return renderPdf(lines)
+    }
 
     @Transactional
     fun createDonation(userSub: String?, command: CreateDonationCommand): AccountDonationResult {
@@ -105,6 +185,78 @@ class AccountDonationService(
         return donationRepository.save(entity).toResult()
     }
 
+    private fun findByFilters(userSub: String, from: OffsetDateTime?, to: OffsetDateTime?): List<DonationPaymentJpaEntity> {
+        validateRange(from, to)
+        return when {
+            from != null && to != null ->
+                donationRepository.findAllByUserSubAndCreatedAtGreaterThanEqualAndCreatedAtLessThanEqualOrderByCreatedAtDesc(
+                    userSub,
+                    from,
+                    to
+                )
+
+            from != null ->
+                donationRepository.findAllByUserSubAndCreatedAtGreaterThanEqualOrderByCreatedAtDesc(userSub, from)
+
+            to != null ->
+                donationRepository.findAllByUserSubAndCreatedAtLessThanEqualOrderByCreatedAtDesc(userSub, to)
+
+            else -> donationRepository.findAllByUserSubOrderByCreatedAtDesc(userSub)
+        }
+    }
+
+    private fun validateRange(from: OffsetDateTime?, to: OffsetDateTime?) {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "from must be less than or equal to to")
+        }
+    }
+
+    private fun escapeCsv(rawValue: String): String {
+        if (!rawValue.contains(',') && !rawValue.contains('"') && !rawValue.contains('\n')) {
+            return rawValue
+        }
+        val escaped = rawValue.replace("\"", "\"\"")
+        return "\"$escaped\""
+    }
+
+    private fun BigDecimal.toMoney(): String =
+        setScale(2, RoundingMode.HALF_UP).toPlainString()
+
+    private fun renderPdf(lines: List<String>): ByteArray {
+        val document = PDDocument()
+        val output = ByteArrayOutputStream()
+        try {
+            var page = PDPage(PDRectangle.A4)
+            document.addPage(page)
+            var content = PDPageContentStream(document, page)
+            content.setFont(PDType1Font.COURIER, 10f)
+            var y = page.mediaBox.height - 40f
+
+            lines.forEach { line ->
+                if (y < 50f) {
+                    content.close()
+                    page = PDPage(PDRectangle.A4)
+                    document.addPage(page)
+                    content = PDPageContentStream(document, page)
+                    content.setFont(PDType1Font.COURIER, 10f)
+                    y = page.mediaBox.height - 40f
+                }
+                content.beginText()
+                content.newLineAtOffset(35f, y)
+                content.showText(line)
+                content.endText()
+                y -= 14f
+            }
+
+            content.close()
+            document.save(output)
+            return output.toByteArray()
+        } finally {
+            document.close()
+            output.close()
+        }
+    }
+
     private fun buildLocalConfirmationUrl(paymentId: UUID): String =
         "https://yookassa.local/checkout/$paymentId"
 
@@ -125,5 +277,6 @@ class AccountDonationService(
 
     companion object {
         private val allowedStatuses = setOf("PENDING", "SUCCEEDED", "CANCELED")
+        private val auditLogger = LoggerFactory.getLogger(AccountDonationService::class.java)
     }
 }

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/account/AdminDonationReportingService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/account/AdminDonationReportingService.kt
@@ -1,0 +1,311 @@
+package com.example.poprogknowledgebaseback.application.account
+
+import com.example.poprogknowledgebaseback.adapters.outbound.persistence.donation.DonationPaymentJpaEntity
+import com.example.poprogknowledgebaseback.adapters.outbound.persistence.donation.SpringDataDonationPaymentRepository
+import java.io.ByteArrayOutputStream
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.OffsetDateTime
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.pdmodel.PDPage
+import org.apache.pdfbox.pdmodel.PDPageContentStream
+import org.apache.pdfbox.pdmodel.common.PDRectangle
+import org.apache.pdfbox.pdmodel.font.PDType1Font
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.server.ResponseStatusException
+
+data class DonationReportingFilters(
+    val from: OffsetDateTime? = null,
+    val to: OffsetDateTime? = null,
+    val status: String? = null
+)
+
+data class DonationKpiReportResult(
+    val totalDonationsCount: Long,
+    val succeededDonationsCount: Long,
+    val pendingDonationsCount: Long,
+    val canceledDonationsCount: Long,
+    val anonymousDonationsCount: Long,
+    val uniqueDonorsCount: Long,
+    val totalAmount: String,
+    val succeededAmount: String,
+    val averageAmount: String,
+    val conversionRatePercent: String,
+    val currencies: List<String>
+)
+
+data class DonationEventResult(
+    val id: String,
+    val eventType: String,
+    val eventAt: String,
+    val status: String,
+    val amount: String,
+    val currency: String,
+    val userSub: String?,
+    val source: String?,
+    val message: String?,
+    val providerPaymentId: String?,
+    val createdAt: String,
+    val updatedAt: String,
+    val paidAt: String?
+)
+
+data class DonationEventPageResult(
+    val items: List<DonationEventResult>,
+    val totalCount: Long,
+    val page: Int,
+    val size: Int
+)
+
+@Service
+class AdminDonationReportingService(
+    private val donationRepository: SpringDataDonationPaymentRepository
+) {
+
+    @Transactional(readOnly = true)
+    fun getKpi(filters: DonationReportingFilters): DonationKpiReportResult {
+        val donations = findByFilters(filters.copy(status = null))
+        val totalCount = donations.size.toLong()
+        val succeeded = donations.filter { it.status == "SUCCEEDED" }
+        val pending = donations.filter { it.status == "PENDING" }
+        val canceled = donations.filter { it.status == "CANCELED" }
+        val anonymousCount = donations.count { it.userSub.isNullOrBlank() }.toLong()
+        val uniqueDonorsCount = donations.mapNotNull { it.userSub?.takeIf(String::isNotBlank) }.toSet().size.toLong()
+        val totalAmount = donations.fold(BigDecimal.ZERO) { acc, donation -> acc + donation.amount }
+        val succeededAmount = succeeded.fold(BigDecimal.ZERO) { acc, donation -> acc + donation.amount }
+        val averageAmount = if (totalCount > 0) {
+            totalAmount.divide(BigDecimal.valueOf(totalCount), 2, RoundingMode.HALF_UP)
+        } else {
+            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+        }
+        val conversionRatePercent = if (totalCount > 0) {
+            BigDecimal.valueOf(succeeded.size.toLong())
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(totalCount), 2, RoundingMode.HALF_UP)
+        } else {
+            BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP)
+        }
+        val currencies = donations.map { it.currency }.distinct().sorted()
+
+        return DonationKpiReportResult(
+            totalDonationsCount = totalCount,
+            succeededDonationsCount = succeeded.size.toLong(),
+            pendingDonationsCount = pending.size.toLong(),
+            canceledDonationsCount = canceled.size.toLong(),
+            anonymousDonationsCount = anonymousCount,
+            uniqueDonorsCount = uniqueDonorsCount,
+            totalAmount = totalAmount.toMoney(),
+            succeededAmount = succeededAmount.toMoney(),
+            averageAmount = averageAmount.toMoney(),
+            conversionRatePercent = conversionRatePercent.toMoney(),
+            currencies = currencies
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getEvents(filters: DonationReportingFilters, page: Int, size: Int): DonationEventPageResult {
+        val sanitizedPage = page.coerceAtLeast(0)
+        val sanitizedSize = size.coerceIn(1, 200)
+        val events = findEventResults(filters)
+        val fromIndex = (sanitizedPage * sanitizedSize).coerceAtMost(events.size)
+        val items = events.drop(fromIndex).take(sanitizedSize)
+
+        return DonationEventPageResult(
+            items = items,
+            totalCount = events.size.toLong(),
+            page = sanitizedPage,
+            size = sanitizedSize
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun exportEventsCsv(filters: DonationReportingFilters, limit: Int): ByteArray {
+        val events = findEventResults(filters, limit)
+        val header = listOf(
+            "id",
+            "eventType",
+            "eventAt",
+            "status",
+            "amount",
+            "currency",
+            "userSub",
+            "source",
+            "message",
+            "providerPaymentId",
+            "createdAt",
+            "updatedAt",
+            "paidAt"
+        ).joinToString(",")
+        val rows = events.joinToString("\n") { event ->
+            listOf(
+                event.id,
+                event.eventType,
+                event.eventAt,
+                event.status,
+                event.amount,
+                event.currency,
+                event.userSub.orEmpty(),
+                event.source.orEmpty(),
+                event.message.orEmpty(),
+                event.providerPaymentId.orEmpty(),
+                event.createdAt,
+                event.updatedAt,
+                event.paidAt.orEmpty()
+            ).joinToString(",") { escapeCsv(it) }
+        }
+        return "$header\n$rows\n".toByteArray(Charsets.UTF_8)
+    }
+
+    @Transactional(readOnly = true)
+    fun exportEventsPdf(filters: DonationReportingFilters, limit: Int): ByteArray {
+        val events = findEventResults(filters, limit)
+        val title = "POPROG Donations Events Report"
+        val lines = mutableListOf(title, "")
+        events.forEachIndexed { index, event ->
+            val line = buildString {
+                append(index + 1)
+                append(". ")
+                append(event.eventAt)
+                append(" | ")
+                append(event.eventType)
+                append(" | ")
+                append(event.status)
+                append(" | ")
+                append(event.amount)
+                append(" ")
+                append(event.currency)
+                append(" | user=")
+                append(event.userSub ?: "anonymous")
+            }.take(160)
+            lines += line
+        }
+        return renderPdf(lines)
+    }
+
+    private fun findEventResults(filters: DonationReportingFilters, limit: Int? = null): List<DonationEventResult> {
+        val rawEvents = findByFilters(filters)
+            .sortedByDescending { resolveEventAt(it) }
+            .map { donation ->
+                DonationEventResult(
+                    id = donation.id.toString(),
+                    eventType = resolveEventType(donation.status),
+                    eventAt = resolveEventAt(donation).toString(),
+                    status = donation.status,
+                    amount = donation.amount.toMoney(),
+                    currency = donation.currency,
+                    userSub = donation.userSub,
+                    source = donation.source,
+                    message = donation.message,
+                    providerPaymentId = donation.providerPaymentId,
+                    createdAt = donation.createdAt.toString(),
+                    updatedAt = donation.updatedAt.toString(),
+                    paidAt = donation.paidAt?.toString()
+                )
+            }
+        return if (limit == null) {
+            rawEvents
+        } else {
+            rawEvents.take(limit.coerceIn(1, 5000))
+        }
+    }
+
+    private fun findByFilters(filters: DonationReportingFilters): List<DonationPaymentJpaEntity> {
+        validateRange(filters.from, filters.to)
+        val normalizedStatus = filters.status?.trim()?.uppercase()
+        if (normalizedStatus != null && normalizedStatus !in allowedStatuses) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported status filter")
+        }
+
+        val base = when {
+            filters.from != null && filters.to != null ->
+                donationRepository.findAllByCreatedAtGreaterThanEqualAndCreatedAtLessThanEqualOrderByCreatedAtDesc(
+                    filters.from,
+                    filters.to
+                )
+
+            filters.from != null ->
+                donationRepository.findAllByCreatedAtGreaterThanEqualOrderByCreatedAtDesc(filters.from)
+
+            filters.to != null ->
+                donationRepository.findAllByCreatedAtLessThanEqualOrderByCreatedAtDesc(filters.to)
+
+            else -> donationRepository.findAllByOrderByCreatedAtDesc()
+        }
+
+        return if (normalizedStatus == null) {
+            base
+        } else {
+            base.filter { it.status == normalizedStatus }
+        }
+    }
+
+    private fun validateRange(from: OffsetDateTime?, to: OffsetDateTime?) {
+        if (from != null && to != null && from.isAfter(to)) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "from must be less than or equal to to")
+        }
+    }
+
+    private fun resolveEventAt(donation: DonationPaymentJpaEntity): OffsetDateTime =
+        when (donation.status) {
+            "SUCCEEDED" -> donation.paidAt ?: donation.updatedAt
+            else -> donation.updatedAt
+        }
+
+    private fun resolveEventType(status: String): String =
+        when (status) {
+            "SUCCEEDED" -> "DONATION_SUCCEEDED"
+            "CANCELED" -> "DONATION_CANCELED"
+            else -> "DONATION_PENDING"
+        }
+
+    private fun escapeCsv(rawValue: String): String {
+        if (!rawValue.contains(',') && !rawValue.contains('"') && !rawValue.contains('\n')) {
+            return rawValue
+        }
+        val escaped = rawValue.replace("\"", "\"\"")
+        return "\"$escaped\""
+    }
+
+    private fun BigDecimal.toMoney(): String =
+        setScale(2, RoundingMode.HALF_UP).toPlainString()
+
+    private fun renderPdf(lines: List<String>): ByteArray {
+        val document = PDDocument()
+        val output = ByteArrayOutputStream()
+        try {
+            var page = PDPage(PDRectangle.A4)
+            document.addPage(page)
+            var content = PDPageContentStream(document, page)
+            content.setFont(PDType1Font.COURIER, 10f)
+            var y = page.mediaBox.height - 40f
+
+            lines.forEach { line ->
+                if (y < 50f) {
+                    content.close()
+                    page = PDPage(PDRectangle.A4)
+                    document.addPage(page)
+                    content = PDPageContentStream(document, page)
+                    content.setFont(PDType1Font.COURIER, 10f)
+                    y = page.mediaBox.height - 40f
+                }
+                content.beginText()
+                content.newLineAtOffset(35f, y)
+                content.showText(line)
+                content.endText()
+                y -= 14f
+            }
+            content.close()
+            document.save(output)
+            return output.toByteArray()
+        } finally {
+            document.close()
+            output.close()
+        }
+    }
+
+    companion object {
+        private val allowedStatuses = setOf("PENDING", "SUCCEEDED", "CANCELED")
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AiAssistantService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AiAssistantService.kt
@@ -11,7 +11,9 @@ import com.example.poprogknowledgebaseback.domain.assistant.port.ChatConversatio
 import com.example.poprogknowledgebaseback.domain.search.SearchSourceType
 import java.time.Clock
 import java.util.UUID
+import org.slf4j.LoggerFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -22,8 +24,10 @@ class AiAssistantService(
     private val chatConversationPersistencePort: ChatConversationPersistencePort,
     private val documentQuestionResolver: DocumentQuestionResolver,
     private val contextPromptBuilder: AssistantContextPromptBuilder,
-    private val clock: Clock
+    private val clock: Clock,
+    private val environment: Environment
 ) : AiAssistantUseCase {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @Transactional
     override fun chat(command: AssistantChatCommand): AssistantChatResult {
@@ -59,7 +63,15 @@ class AiAssistantService(
             ) + history + command.messages
         }
 
-        val assistantResponse = aiAssistantPort.complete(messageList)
+        val assistantResponse = runCatching { aiAssistantPort.complete(messageList) }
+            .getOrElse { error ->
+                if (!isLocalLikeProfile()) {
+                    throw error
+                }
+
+                log.warn("GigaChat request failed in local/dev profile. Returning local fallback response.", error)
+                buildLocalFallbackResponse(command.messages)
+            }
         persistConversationMessages(conversation.id, command.messages, assistantResponse)
 
         return AssistantChatResult(
@@ -182,6 +194,29 @@ class AiAssistantService(
         }
         sanitized = sanitized.replace(Regex("\\s+"), " ").trim()
         return if (sanitized.length >= 3) sanitized else message
+    }
+
+    private fun isLocalLikeProfile(): Boolean {
+        val activeProfiles = environment.activeProfiles.map { it.lowercase() }.toSet()
+        return activeProfiles.any { it == "local" || it == "dev" }
+    }
+
+    private fun buildLocalFallbackResponse(requestMessages: List<AiChatMessage>): AiAssistantResponse {
+        val lastUserMessage = requestMessages.lastOrNull { it.role == AiChatMessageRole.USER }?.content?.trim().orEmpty()
+        val content = if (lastUserMessage.isBlank()) {
+            "Локальный режим: внешний ИИ-сервис сейчас недоступен. История чата сохранена, но ответ модели временно заменён локальной заглушкой."
+        } else {
+            "Локальный режим: внешний ИИ-сервис сейчас недоступен. История чата сохранена, но ответ модели временно заменён локальной заглушкой. Последний запрос: \"$lastUserMessage\"."
+        }
+
+        return AiAssistantResponse(
+            content = content,
+            model = "local-fallback",
+            finishReason = "stop",
+            promptTokens = null,
+            completionTokens = null,
+            totalTokens = null
+        )
     }
 
     private fun persistConversationMessages(

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/NoOpAiAssistantService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/NoOpAiAssistantService.kt
@@ -1,13 +1,100 @@
 package com.example.poprogknowledgebaseback.application.assistant
 
+import com.example.poprogknowledgebaseback.domain.assistant.AiChatMessageRole
+import com.example.poprogknowledgebaseback.domain.assistant.ChatConversation
+import com.example.poprogknowledgebaseback.domain.assistant.ChatConversationNotFoundException
+import com.example.poprogknowledgebaseback.domain.assistant.StoredChatMessage
+import com.example.poprogknowledgebaseback.domain.assistant.port.ChatConversationPersistencePort
+import java.time.Clock
+import java.util.UUID
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.core.env.Environment
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.web.server.ResponseStatusException
 
 @Service
 @ConditionalOnProperty(name = ["app.gigachat.enabled"], havingValue = "false", matchIfMissing = true)
-class NoOpAiAssistantService : AiAssistantUseCase {
+class NoOpAiAssistantService(
+    private val chatConversationPersistencePort: ChatConversationPersistencePort,
+    private val clock: Clock,
+    private val environment: Environment
+) : AiAssistantUseCase {
 
+    @Transactional
     override fun chat(command: AssistantChatCommand): AssistantChatResult {
-        error("GigaChat integration is disabled")
+        require(command.messages.isNotEmpty()) { "At least one chat message is required" }
+
+        if (!isLocalLikeProfile()) {
+            throw ResponseStatusException(
+                HttpStatus.SERVICE_UNAVAILABLE,
+                "GigaChat integration is disabled"
+            )
+        }
+
+        val chatId = command.chatId ?: UUID.randomUUID()
+        val conversation = command.chatId?.let { existingChatId ->
+            val existingConversation = chatConversationPersistencePort.findConversationById(existingChatId)
+                ?: throw ChatConversationNotFoundException(existingChatId)
+            if (existingConversation.ownerSub != null && command.requesterSub != existingConversation.ownerSub) {
+                throw ChatConversationNotFoundException(existingChatId)
+            }
+            existingConversation
+        } ?: chatConversationPersistencePort.saveConversation(
+            ChatConversation(
+                id = chatId,
+                createdAt = clock.instant(),
+                ownerSub = command.requesterSub
+            )
+        )
+
+        val lastUserMessage = command.messages.lastOrNull { it.role == AiChatMessageRole.USER }?.content?.trim().orEmpty()
+        val fallbackResponse = if (lastUserMessage.isBlank()) {
+            "Локальный режим: интеграция GigaChat отключена. История чата сохранена, но ответ модели сейчас недоступен."
+        } else {
+            "Локальный режим: интеграция GigaChat отключена. История чата сохранена, но полноценный ответ модели сейчас недоступен. Последний запрос: \"$lastUserMessage\"."
+        }
+
+        persistConversationMessages(conversation.id, command.messages, fallbackResponse)
+
+        return AssistantChatResult(
+            chatId = conversation.id,
+            content = fallbackResponse,
+            model = "local-fallback",
+            finishReason = "stop",
+            promptTokens = null,
+            completionTokens = null,
+            totalTokens = null,
+            documentHints = emptyList()
+        )
+    }
+
+    private fun isLocalLikeProfile(): Boolean {
+        val activeProfiles = environment.activeProfiles.map { it.lowercase() }.toSet()
+        return activeProfiles.any { it == "local" || it == "dev" }
+    }
+
+    private fun persistConversationMessages(
+        chatId: UUID,
+        requestMessages: List<com.example.poprogknowledgebaseback.domain.assistant.AiChatMessage>,
+        assistantResponse: String
+    ) {
+        val now = clock.instant()
+        val messages = requestMessages.mapIndexed { index, message ->
+            StoredChatMessage(
+                chatId = chatId,
+                role = message.role,
+                content = message.content,
+                createdAt = now.plusMillis(index.toLong())
+            )
+        } + StoredChatMessage(
+            chatId = chatId,
+            role = AiChatMessageRole.ASSISTANT,
+            content = assistantResponse,
+            createdAt = now.plusMillis(requestMessages.size.toLong())
+        )
+
+        chatConversationPersistencePort.saveMessages(messages)
     }
 }

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/metrics/ProductMetricsService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/metrics/ProductMetricsService.kt
@@ -1,0 +1,213 @@
+package com.example.poprogknowledgebaseback.application.metrics
+
+import com.example.poprogknowledgebaseback.adapters.outbound.persistence.metrics.ProductMetricEventJpaEntity
+import com.example.poprogknowledgebaseback.adapters.outbound.persistence.metrics.SpringDataProductMetricEventRepository
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.Clock
+import java.time.OffsetDateTime
+import java.time.temporal.TemporalAdjusters
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ObjectMapper
+
+data class ProductMetricEventCommand(
+    val eventType: String,
+    val route: String,
+    val referrer: String?,
+    val sessionId: String,
+    val userKey: String?,
+    val timestampClient: OffsetDateTime,
+    val payload: Map<String, Any?>
+)
+
+data class DailyActiveUsersPoint(
+    val day: String,
+    val uniqueUsers: Long
+)
+
+data class WeeklyActiveUsersPoint(
+    val weekStart: String,
+    val uniqueUsers: Long
+)
+
+data class DauWauReportResult(
+    val uniqueUserDefinition: String,
+    val daily: List<DailyActiveUsersPoint>,
+    val weekly: List<WeeklyActiveUsersPoint>
+)
+
+data class SearchSuccessDayResult(
+    val day: String,
+    val submittedCount: Long,
+    val successfulCount: Long,
+    val searchSuccessRatePercent: String
+)
+
+data class SearchSuccessReportResult(
+    val daily: List<SearchSuccessDayResult>
+)
+
+data class SourceTypeCtrResult(
+    val sourceType: String,
+    val impressions: Long,
+    val clicks: Long,
+    val clickThroughRatePercent: String
+)
+
+data class SourceTypeCtrReportResult(
+    val items: List<SourceTypeCtrResult>
+)
+
+@Service
+class ProductMetricsService(
+    private val repository: SpringDataProductMetricEventRepository,
+    private val objectMapper: ObjectMapper,
+    private val clock: Clock
+) {
+
+    @Transactional
+    fun saveEvent(command: ProductMetricEventCommand): Long {
+        val normalizedUserKey = command.userKey?.trim()?.takeIf { it.isNotBlank() } ?: command.sessionId.trim()
+        val entity = ProductMetricEventJpaEntity(
+            eventType = command.eventType.trim(),
+            route = command.route.trim(),
+            referrer = command.referrer?.trim()?.takeIf { it.isNotBlank() },
+            sessionId = command.sessionId.trim(),
+            userKey = normalizedUserKey,
+            timestampClient = command.timestampClient,
+            timestampServer = OffsetDateTime.now(clock),
+            payloadJson = objectMapper.writeValueAsString(command.payload)
+        )
+        return repository.save(entity).id ?: 0L
+    }
+
+    @Transactional(readOnly = true)
+    fun getDauWauReport(from: OffsetDateTime?, to: OffsetDateTime?): DauWauReportResult {
+        val events = findInRange(from, to)
+        val daily = events
+            .groupBy { it.timestampClient.toLocalDate() }
+            .toSortedMap()
+            .map { (day, values) ->
+                DailyActiveUsersPoint(
+                    day = day.toString(),
+                    uniqueUsers = values.map { it.userKey }.toSet().size.toLong()
+                )
+            }
+        val weekly = events
+            .groupBy { it.timestampClient.toLocalDate().with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY)) }
+            .toSortedMap()
+            .map { (weekStart, values) ->
+                WeeklyActiveUsersPoint(
+                    weekStart = weekStart.toString(),
+                    uniqueUsers = values.map { it.userKey }.toSet().size.toLong()
+                )
+            }
+
+        return DauWauReportResult(
+            uniqueUserDefinition = "subject авторизованного пользователя или sessionId анонимной сессии",
+            daily = daily,
+            weekly = weekly
+        )
+    }
+
+    @Transactional(readOnly = true)
+    fun getSearchSuccessReport(from: OffsetDateTime?, to: OffsetDateTime?): SearchSuccessReportResult {
+        val events = findInRange(from, to)
+        val successfulQueries = events
+            .filter { it.eventType == "search_result_opened" || it.eventType == "search_result_click" }
+            .mapNotNull { event ->
+                val payload = payloadNode(event)
+                val queryId = payload["queryId"]?.asText()?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                "${event.sessionId}::$queryId"
+            }
+            .toSet()
+
+        val submittedByDay = events
+            .filter { it.eventType == "search_query_submitted" || it.eventType == "search_submitted" }
+            .groupBy { it.timestampClient.toLocalDate() }
+            .toSortedMap()
+
+        val daily = submittedByDay.map { (day, submittedEvents) ->
+            val successfulCount = submittedEvents.count { event ->
+                val queryId = payloadNode(event)["queryId"]?.asText()?.takeIf { it.isNotBlank() } ?: return@count false
+                successfulQueries.contains("${event.sessionId}::$queryId")
+            }.toLong()
+            val submittedCount = submittedEvents.size.toLong()
+
+            SearchSuccessDayResult(
+                day = day.toString(),
+                submittedCount = submittedCount,
+                successfulCount = successfulCount,
+                searchSuccessRatePercent = percentage(successfulCount, submittedCount)
+            )
+        }
+
+        return SearchSuccessReportResult(daily = daily)
+    }
+
+    @Transactional(readOnly = true)
+    fun getCtrReport(from: OffsetDateTime?, to: OffsetDateTime?): SourceTypeCtrReportResult {
+        val events = findInRange(from, to)
+        val impressions = mutableMapOf<String, Long>()
+        val clicks = mutableMapOf<String, Long>()
+
+        events.filter { it.eventType == "search_result_shown" }.forEach { event ->
+            val payload = payloadNode(event)
+            mergeCount(impressions, "publication", payload["publicationCount"]?.asLong() ?: 0L)
+            mergeCount(impressions, "student-work", payload["studentWorkCount"]?.asLong() ?: 0L)
+        }
+
+        events.filter { it.eventType == "search_result_click" }.forEach { event ->
+            val sourceType = payloadNode(event)["sourceType"]?.asText()?.trim()?.lowercase()
+            if (!sourceType.isNullOrBlank()) {
+                mergeCount(clicks, sourceType, 1L)
+            }
+        }
+
+        val sourceTypes = (impressions.keys + clicks.keys).toSortedSet()
+        val items = sourceTypes.map { sourceType ->
+            val impressionCount = impressions[sourceType] ?: 0L
+            val clickCount = clicks[sourceType] ?: 0L
+            SourceTypeCtrResult(
+                sourceType = sourceType,
+                impressions = impressionCount,
+                clicks = clickCount,
+                clickThroughRatePercent = percentage(clickCount, impressionCount)
+            )
+        }
+
+        return SourceTypeCtrReportResult(items = items)
+    }
+
+    private fun findInRange(from: OffsetDateTime?, to: OffsetDateTime?): List<ProductMetricEventJpaEntity> {
+        val normalizedTo = to ?: OffsetDateTime.now(clock)
+        val normalizedFrom = from ?: normalizedTo.minusDays(30)
+        return repository.findAll()
+            .sortedBy { it.timestampServer }
+            .filter { event ->
+                !event.timestampClient.isBefore(normalizedFrom) && !event.timestampClient.isAfter(normalizedTo)
+            }
+    }
+
+    private fun payloadNode(event: ProductMetricEventJpaEntity): JsonNode =
+        objectMapper.readTree(event.payloadJson)
+
+    private fun mergeCount(target: MutableMap<String, Long>, key: String, delta: Long) {
+        if (delta <= 0L) {
+            return
+        }
+        target[key] = (target[key] ?: 0L) + delta
+    }
+
+    private fun percentage(numerator: Long, denominator: Long): String {
+        if (denominator <= 0L) {
+            return "0.00"
+        }
+        return BigDecimal.valueOf(numerator)
+            .multiply(BigDecimal.valueOf(100))
+            .divide(BigDecimal.valueOf(denominator), 2, RoundingMode.HALF_UP)
+            .toPlainString()
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/config/GigaChatConfig.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/config/GigaChatConfig.kt
@@ -3,6 +3,7 @@ package com.example.poprogknowledgebaseback.config
 import java.io.FileInputStream
 import java.security.KeyStore
 import java.time.Clock
+import org.slf4j.LoggerFactory
 import org.apache.hc.client5.http.classic.HttpClient
 import org.apache.hc.client5.http.impl.classic.HttpClients
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder
@@ -20,11 +21,13 @@ import org.springframework.web.client.RestClient
 @Configuration
 @EnableConfigurationProperties(GigaChatProperties::class)
 class GigaChatConfig {
+    private val log = LoggerFactory.getLogger(javaClass)
 
     @Bean
     fun clock(): Clock = Clock.systemUTC()
 
     @Bean
+    @ConditionalOnProperty(name = ["app.gigachat.enabled"], havingValue = "true")
     fun restClientBuilder(properties: GigaChatProperties): RestClient.Builder {
         val requestFactory = HttpComponentsClientHttpRequestFactory(gigaChatHttpClient(properties))
         return RestClient.builder().requestFactory(requestFactory)
@@ -58,26 +61,39 @@ class GigaChatConfig {
             return HttpClients.createDefault()
         }
 
-        require(properties.trustStorePassword.isNotBlank()) {
-            "GigaChat trust store password is required when trust store path is configured"
+        if (properties.trustStorePassword.isBlank()) {
+            log.warn(
+                "GigaChat trust store path is configured ('{}') but password is empty. Falling back to default JVM trust store.",
+                trustStorePath
+            )
+            return HttpClients.createDefault()
         }
 
-        val trustStore = KeyStore.getInstance(properties.trustStoreType).apply {
-            FileInputStream(trustStorePath).use { input ->
-                load(input, properties.trustStorePassword.toCharArray())
+        return runCatching {
+            val trustStore = KeyStore.getInstance(properties.trustStoreType).apply {
+                FileInputStream(trustStorePath).use { input ->
+                    load(input, properties.trustStorePassword.toCharArray())
+                }
             }
+
+            val sslContext = SSLContextBuilder()
+                .loadTrustMaterial(trustStore, null)
+                .build()
+
+            val connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
+                .setTlsSocketStrategy(DefaultClientTlsStrategy(sslContext))
+                .build()
+
+            HttpClients.custom()
+                .setConnectionManager(connectionManager)
+                .build()
+        }.getOrElse { error ->
+            log.warn(
+                "Cannot initialize GigaChat custom trust store from '{}'. Falling back to default JVM trust store.",
+                trustStorePath,
+                error
+            )
+            HttpClients.createDefault()
         }
-
-        val sslContext = SSLContextBuilder()
-            .loadTrustMaterial(trustStore, null)
-            .build()
-
-        val connectionManager = PoolingHttpClientConnectionManagerBuilder.create()
-            .setTlsSocketStrategy(DefaultClientTlsStrategy(sslContext))
-            .build()
-
-        return HttpClients.custom()
-            .setConnectionManager(connectionManager)
-            .build()
     }
 }

--- a/src/main/resources/db/changelog/016-create-product-metric-event-table.sql
+++ b/src/main/resources/db/changelog/016-create-product-metric-event-table.sql
@@ -1,0 +1,24 @@
+--liquibase formatted sql
+
+--changeset codex:016-create-product-metric-event-table
+CREATE TABLE product_metric_event
+(
+    id               BIGSERIAL PRIMARY KEY,
+    event_type       VARCHAR(64)                  NOT NULL,
+    route            VARCHAR(255)                 NOT NULL,
+    referrer         VARCHAR(2048),
+    session_id       VARCHAR(128)                 NOT NULL,
+    user_key         VARCHAR(128)                 NOT NULL,
+    timestamp_client TIMESTAMPTZ                  NOT NULL,
+    timestamp_server TIMESTAMPTZ                  NOT NULL,
+    payload_json     TEXT                         NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX idx_product_metric_event_server_time
+    ON product_metric_event (timestamp_server ASC);
+
+CREATE INDEX idx_product_metric_event_type_server_time
+    ON product_metric_event (event_type, timestamp_server ASC);
+
+CREATE INDEX idx_product_metric_event_user_key_server_time
+    ON product_metric_event (user_key, timestamp_server ASC);

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -29,3 +29,5 @@ databaseChangeLog:
       file: db/changelog/014-create-favorite-item-table.sql
   - include:
       file: db/changelog/015-create-donation-payment-table.sql
+  - include:
+      file: db/changelog/016-create-product-metric-event-table.sql

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/AccountDonationControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/AccountDonationControllerIntegrationTest.kt
@@ -103,6 +103,108 @@ class AccountDonationControllerIntegrationTest {
         assertEquals("SUCCEEDED", updateJson["status"].asText())
         assertEquals("yoopay-123", updateJson["providerPaymentId"].asText())
         assertTrue(updateJson["paidAt"].asText().isNotBlank())
+
+        val csvResponse = mockMvc.perform(
+            get("/api/account/donations/export.csv")
+                .header("subject", "user-100")
+                .header("email", "user100@example.com")
+                .header("name", "User 100")
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        val csvPayload = csvResponse.contentAsString
+        assertTrue(csvPayload.contains("yoopay-123"))
+        assertTrue(csvPayload.contains(donationId))
+
+        val pdfResponse = mockMvc.perform(
+            get("/api/account/donations/export.pdf")
+                .header("subject", "user-100")
+                .header("email", "user100@example.com")
+                .header("name", "User 100")
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        val pdfPayload = pdfResponse.contentAsByteArray
+        assertTrue(pdfPayload.isNotEmpty())
+        val pdfHeader = String(pdfPayload.copyOfRange(0, minOf(4, pdfPayload.size)))
+        assertEquals("%PDF", pdfHeader)
+    }
+
+    @Test
+    fun `should export only current user donations and support period filter`() {
+        val firstPayload =
+            """
+            {
+              "amount": 400.00,
+              "currency": "RUB",
+              "source": "cabinet",
+              "message": "User 101 donation",
+              "returnUrl": "http://localhost:5173/donate/complete"
+            }
+            """.trimIndent()
+        val secondPayload =
+            """
+            {
+              "amount": 500.00,
+              "currency": "RUB",
+              "source": "cabinet",
+              "message": "User 202 donation",
+              "returnUrl": "http://localhost:5173/donate/complete"
+            }
+            """.trimIndent()
+
+        mockMvc.perform(
+            post("/api/account/donations")
+                .header("subject", "user-101")
+                .header("email", "user101@example.com")
+                .header("name", "User 101")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(firstPayload)
+        )
+            .andExpect(status().isCreated)
+
+        mockMvc.perform(
+            post("/api/account/donations")
+                .header("subject", "user-202")
+                .header("email", "user202@example.com")
+                .header("name", "User 202")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(secondPayload)
+        )
+            .andExpect(status().isCreated)
+
+        val ownCsv = mockMvc.perform(
+            get("/api/account/donations/export.csv")
+                .header("subject", "user-101")
+                .header("email", "user101@example.com")
+                .header("name", "User 101")
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        assertTrue(ownCsv.contains("User 101 donation"))
+        assertTrue(!ownCsv.contains("User 202 donation"))
+
+        val futureCsv = mockMvc.perform(
+            get("/api/account/donations/export.csv")
+                .header("subject", "user-101")
+                .header("email", "user101@example.com")
+                .header("name", "User 101")
+                .param("from", "2100-01-01T00:00:00Z")
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        assertTrue(futureCsv.contains("id,amount,currency,status"))
+        assertTrue(!futureCsv.contains("User 101 donation"))
     }
 
     @Test

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/AdminDonationReportingControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/AdminDonationReportingControllerIntegrationTest.kt
@@ -1,0 +1,187 @@
+package com.example.poprogknowledgebaseback
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.ObjectMapper
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("local")
+class AdminDonationReportingControllerIntegrationTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `should return donations kpi events and exports for admin`() {
+        val createAccountPayload =
+            """
+            {
+              "amount": 1200.00,
+              "currency": "RUB",
+              "source": "cabinet",
+              "message": "Test donation",
+              "returnUrl": "http://localhost:5173/donate/complete"
+            }
+            """.trimIndent()
+
+        val createdDonationJson = objectMapper.readTree(
+            mockMvc.perform(
+                post("/api/account/donations")
+                    .header("subject", "user-200")
+                    .header("email", "user200@example.com")
+                    .header("name", "User 200")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(createAccountPayload)
+            )
+                .andExpect(status().isCreated)
+                .andReturn()
+                .response
+                .contentAsString
+        )
+        val donationId = createdDonationJson["id"].asText()
+
+        val updatePayload =
+            """
+            {
+              "status": "SUCCEEDED",
+              "providerPaymentId": "provider-200"
+            }
+            """.trimIndent()
+
+        mockMvc.perform(
+            post("/api/account/donations/$donationId/status")
+                .header("subject", "user-200")
+                .header("email", "user200@example.com")
+                .header("name", "User 200")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(updatePayload)
+        )
+            .andExpect(status().isOk)
+
+        val createPublicPayload =
+            """
+            {
+              "amount": 300.00,
+              "currency": "RUB",
+              "source": "landing",
+              "message": "Public donation",
+              "returnUrl": "http://localhost:5173/donate"
+            }
+            """.trimIndent()
+
+        mockMvc.perform(
+            post("/api/donations")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(createPublicPayload)
+        )
+            .andExpect(status().isCreated)
+
+        val kpiBody = mockMvc.perform(
+            get("/api/admin/donations/kpi")
+                .header("subject", "admin-1")
+                .header("roles", "ADMIN")
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val kpiJson = objectMapper.readTree(kpiBody)
+        assertEquals(2, kpiJson["totalDonationsCount"].asInt())
+        assertEquals(1, kpiJson["succeededDonationsCount"].asInt())
+        assertEquals(1, kpiJson["pendingDonationsCount"].asInt())
+        assertEquals("1500.00", kpiJson["totalAmount"].asText())
+
+        val eventsBody = mockMvc.perform(
+            get("/api/admin/donations/events")
+                .header("subject", "admin-1")
+                .header("roles", "ADMIN")
+                .param("page", "0")
+                .param("size", "10")
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val eventsJson = objectMapper.readTree(eventsBody)
+        assertEquals(2, eventsJson["totalCount"].asInt())
+        assertEquals(0, eventsJson["page"].asInt())
+        assertEquals(10, eventsJson["size"].asInt())
+        assertTrue(eventsJson["items"].isArray)
+        assertEquals(2, eventsJson["items"].size())
+
+        val csvResponse = mockMvc.perform(
+            get("/api/admin/donations/export.csv")
+                .header("subject", "admin-1")
+                .header("roles", "ADMIN")
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        val csvPayload = csvResponse.contentAsString
+        assertTrue(csvPayload.contains("eventType"))
+        assertTrue(csvPayload.contains("DONATION_SUCCEEDED"))
+
+        val pdfResponse = mockMvc.perform(
+            get("/api/admin/donations/export.pdf")
+                .header("subject", "admin-1")
+                .header("roles", "ADMIN")
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+
+        val pdfPayload = pdfResponse.contentAsByteArray
+        assertTrue(pdfPayload.isNotEmpty())
+        val header = String(pdfPayload.copyOfRange(0, minOf(4, pdfPayload.size)))
+        assertEquals("%PDF", header)
+    }
+
+    @Test
+    fun `should reject donations reporting for non admin and anonymous users`() {
+        mockMvc.perform(
+            get("/api/admin/donations/kpi")
+                .header("subject", "user-regular")
+                .header("roles", "USER")
+        )
+            .andExpect(status().isForbidden)
+
+        mockMvc.perform(get("/api/admin/donations/kpi"))
+            .andExpect(status().isUnauthorized)
+    }
+
+    companion object {
+        @Container
+        private val postgres = PostgreSQLContainer("postgres:18")
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerDataSource(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/AiAssistantLocalDegradationIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/AiAssistantLocalDegradationIntegrationTest.kt
@@ -1,0 +1,105 @@
+package com.example.poprogknowledgebaseback
+
+import com.example.poprogknowledgebaseback.domain.assistant.AiAssistantResponse
+import com.example.poprogknowledgebaseback.domain.assistant.AiChatMessage
+import com.example.poprogknowledgebaseback.domain.assistant.port.AiAssistantPort
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.springframework.web.client.ResourceAccessException
+import tools.jackson.databind.ObjectMapper
+
+@SpringBootTest(
+    properties = [
+        "app.gigachat.enabled=true"
+    ]
+)
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("local")
+class AiAssistantLocalDegradationIntegrationTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `should return local fallback when gigachat request fails in local profile`() {
+        val responseBody = mockMvc.perform(
+            post("/api/assistant/chat")
+                .contentType("application/json")
+                .content(
+                    """
+                    {
+                      "messages": [
+                        { "role": "user", "content": "Привет, помоги с документом" }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val response = objectMapper.readTree(responseBody)
+        val chatId = UUID.fromString(response["chatId"].asText())
+        assertEquals("local-fallback", response["model"].asText())
+        assertTrue(response["content"].asText().contains("Локальный режим"))
+
+        val historyBody = mockMvc.perform(get("/api/assistant/chats/{chatId}/messages", chatId))
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val history = objectMapper.readTree(historyBody)
+        assertEquals(2, history["messages"].size())
+        assertEquals("assistant", history["messages"][1]["role"].asText())
+        assertTrue(history["messages"][1]["content"].asText().contains("Локальный режим"))
+    }
+
+    companion object {
+        @Container
+        private val postgres = PostgreSQLContainer("postgres:18")
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerDataSource(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+
+    @TestConfiguration
+    class FailingAssistantConfig {
+        @Bean
+        @Primary
+        fun failingAiAssistantPort(): AiAssistantPort = object : AiAssistantPort {
+            override fun complete(messages: List<AiChatMessage>): AiAssistantResponse {
+                throw ResourceAccessException("Simulated TLS failure")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/AiAssistantLocalFallbackIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/AiAssistantLocalFallbackIntegrationTest.kt
@@ -1,0 +1,84 @@
+package com.example.poprogknowledgebaseback
+
+import java.util.UUID
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.ObjectMapper
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("local")
+class AiAssistantLocalFallbackIntegrationTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `should return local fallback response and persist history when gigachat is disabled`() {
+        val responseBody = mockMvc.perform(
+            post("/api/assistant/chat")
+                .contentType("application/json")
+                .content(
+                    """
+                    {
+                      "messages": [
+                        { "role": "user", "content": "Привет, что умеешь?" }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val response = objectMapper.readTree(responseBody)
+        val chatId = UUID.fromString(response["chatId"].asText())
+        assertEquals("local-fallback", response["model"].asText())
+        assertTrue(response["content"].asText().contains("Локальный режим"))
+
+        val historyBody = mockMvc.perform(get("/api/assistant/chats/{chatId}/messages", chatId))
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val history = objectMapper.readTree(historyBody)
+        assertEquals(2, history["messages"].size())
+        assertEquals("user", history["messages"][0]["role"].asText())
+        assertEquals("assistant", history["messages"][1]["role"].asText())
+        assertTrue(history["messages"][1]["content"].asText().contains("Локальный режим"))
+    }
+
+    companion object {
+        @Container
+        private val postgres = PostgreSQLContainer("postgres:18")
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerDataSource(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/OpenApiContractIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/OpenApiContractIntegrationTest.kt
@@ -53,6 +53,16 @@ class OpenApiContractIntegrationTest {
         assertTrue(paths.has("/api/account/chats"))
         assertTrue(paths.has("/api/account/favorites"))
         assertTrue(paths.has("/api/account/donations"))
+        assertTrue(paths.has("/api/account/donations/export.csv"))
+        assertTrue(paths.has("/api/account/donations/export.pdf"))
+        assertTrue(paths.has("/api/admin/donations/kpi"))
+        assertTrue(paths.has("/api/admin/donations/events"))
+        assertTrue(paths.has("/api/admin/donations/export.csv"))
+        assertTrue(paths.has("/api/admin/donations/export.pdf"))
+        assertTrue(paths.has("/api/metrics/events"))
+        assertTrue(paths.has("/api/metrics/reports/dau-wau"))
+        assertTrue(paths.has("/api/metrics/reports/search-success"))
+        assertTrue(paths.has("/api/metrics/reports/ctr"))
         assertTrue(paths.has("/api/market/apps"))
         assertTrue(paths.has("/api/market/categories"))
         assertTrue(paths.has("/api/donations"))
@@ -87,7 +97,11 @@ class OpenApiContractIntegrationTest {
             "/api/projects/menu/promos" to "post",
             "/api/projects/menu/promos/{id}" to "put",
             "/api/projects/menu/promos/{id}" to "delete",
-            "/api/projects/menu/resources/upload" to "post"
+            "/api/projects/menu/resources/upload" to "post",
+            "/api/admin/donations/kpi" to "get",
+            "/api/admin/donations/events" to "get",
+            "/api/admin/donations/export.csv" to "get",
+            "/api/admin/donations/export.pdf" to "get"
         )
 
         adminOperations.forEach { (path, method) ->

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/ProductMetricsControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/ProductMetricsControllerIntegrationTest.kt
@@ -1,0 +1,261 @@
+package com.example.poprogknowledgebaseback
+
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.databind.ObjectMapper
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+@ActiveProfiles("local")
+class ProductMetricsControllerIntegrationTest {
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
+
+    @Test
+    fun `should ingest events and build dau wau ssr and ctr reports`() {
+        saveEvent(
+            """
+            {
+              "eventType": "page_view",
+              "route": "/home",
+              "referrer": "http://localhost:5173/",
+              "sessionId": "session-a",
+              "userKey": "user-a",
+              "timestampClient": "2026-04-01T09:00:00Z",
+              "payload": {}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "page_view",
+              "route": "/docs",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-b",
+              "userKey": "user-b",
+              "timestampClient": "2026-04-01T10:00:00Z",
+              "payload": {}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "search_query_submitted",
+              "route": "/home",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-a",
+              "userKey": "user-a",
+              "timestampClient": "2026-04-01T10:10:00Z",
+              "payload": {"queryId":"q-1","query":"rust"}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "search_result_shown",
+              "route": "/home",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-a",
+              "userKey": "user-a",
+              "timestampClient": "2026-04-01T10:10:01Z",
+              "payload": {"queryId":"q-1","publicationCount":2,"studentWorkCount":1}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "search_result_opened",
+              "route": "/home",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-a",
+              "userKey": "user-a",
+              "timestampClient": "2026-04-01T10:10:02Z",
+              "payload": {"queryId":"q-1","sourceType":"publication"}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "search_result_click",
+              "route": "/home",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-a",
+              "userKey": "user-a",
+              "timestampClient": "2026-04-01T10:10:03Z",
+              "payload": {"queryId":"q-1","sourceType":"publication"}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "search_query_submitted",
+              "route": "/home",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-b",
+              "userKey": "user-b",
+              "timestampClient": "2026-04-01T11:10:00Z",
+              "payload": {"queryId":"q-2","query":"zig"}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "search_result_shown",
+              "route": "/home",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-b",
+              "userKey": "user-b",
+              "timestampClient": "2026-04-01T11:10:01Z",
+              "payload": {"queryId":"q-2","publicationCount":0,"studentWorkCount":1}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "search_query_submitted",
+              "route": "/home",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-c",
+              "userKey": "session-c",
+              "timestampClient": "2026-04-02T08:00:00Z",
+              "payload": {"queryId":"q-3","query":"post"}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "search_result_shown",
+              "route": "/home",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-c",
+              "userKey": "session-c",
+              "timestampClient": "2026-04-02T08:00:01Z",
+              "payload": {"queryId":"q-3","publicationCount":0,"studentWorkCount":3}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "search_result_opened",
+              "route": "/home",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-c",
+              "userKey": "session-c",
+              "timestampClient": "2026-04-02T08:00:02Z",
+              "payload": {"queryId":"q-3","sourceType":"student-work"}
+            }
+            """.trimIndent()
+        )
+        saveEvent(
+            """
+            {
+              "eventType": "search_result_click",
+              "route": "/home",
+              "referrer": "http://localhost:5173/home",
+              "sessionId": "session-c",
+              "userKey": "session-c",
+              "timestampClient": "2026-04-02T08:00:03Z",
+              "payload": {"queryId":"q-3","sourceType":"student-work"}
+            }
+            """.trimIndent()
+        )
+
+        val dauWauBody = mockMvc.perform(get("/api/metrics/reports/dau-wau"))
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val dauWauJson = objectMapper.readTree(dauWauBody)
+        assertEquals(
+            "subject авторизованного пользователя или sessionId анонимной сессии",
+            dauWauJson["uniqueUserDefinition"].asText()
+        )
+        assertEquals(2, dauWauJson["daily"][0]["uniqueUsers"].asInt())
+
+        val searchSuccessBody = mockMvc.perform(get("/api/metrics/reports/search-success"))
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val searchSuccessJson = objectMapper.readTree(searchSuccessBody)
+        assertEquals(2, searchSuccessJson["daily"].size())
+        assertEquals(2, searchSuccessJson["daily"][0]["submittedCount"].asInt())
+        assertEquals(1, searchSuccessJson["daily"][0]["successfulCount"].asInt())
+        assertEquals("50.00", searchSuccessJson["daily"][0]["searchSuccessRatePercent"].asText())
+
+        val ctrBody = mockMvc.perform(get("/api/metrics/reports/ctr"))
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val ctrJson = objectMapper.readTree(ctrBody)
+        val ctrByType = ctrJson["items"].associateBy { it["sourceType"].asText() }
+        assertEquals(2, ctrByType["publication"]?.get("impressions")?.asInt())
+        assertEquals(1, ctrByType["publication"]?.get("clicks")?.asInt())
+        assertEquals("50.00", ctrByType["publication"]?.get("clickThroughRatePercent")?.asText())
+        assertEquals(5, ctrByType["student-work"]?.get("impressions")?.asInt())
+        assertEquals(1, ctrByType["student-work"]?.get("clicks")?.asInt())
+        assertEquals("20.00", ctrByType["student-work"]?.get("clickThroughRatePercent")?.asText())
+    }
+
+    private fun saveEvent(payload: String) {
+        val responseBody = mockMvc.perform(
+            post("/api/metrics/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+        )
+            .andExpect(status().isAccepted)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val responseJson = objectMapper.readTree(responseBody)
+        assertTrue(responseJson["id"].asLong() > 0)
+    }
+
+    companion object {
+        @Container
+        private val postgres = PostgreSQLContainer("postgres:18")
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun registerDataSource(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+        }
+    }
+}

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/PublicationControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/PublicationControllerIntegrationTest.kt
@@ -153,6 +153,93 @@ class PublicationControllerIntegrationTest {
         assertTrue(created["link"].requiredText().startsWith("/files/publications/"))
     }
 
+    @Test
+    fun `should reject non-pdf upload for publication`() {
+        val metadata = MockMultipartFile(
+            "metadata",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            """
+            {
+              "year": 2026,
+              "authors": "Upload Author",
+              "theme": "Upload Theme",
+              "published": "Upload Published"
+            }
+            """.trimIndent().toByteArray()
+        )
+        val file = MockMultipartFile(
+            "file",
+            "publication.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "plain-text".toByteArray()
+        )
+
+        mockMvc.perform(
+            multipart("/api/publications/upload")
+                .file(metadata)
+                .file(file)
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return uploaded pdf via api files endpoint`() {
+        val metadata = MockMultipartFile(
+            "metadata",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            """
+            {
+              "year": 2026,
+              "authors": "File API Author",
+              "theme": "File API Theme",
+              "published": "File API Published"
+            }
+            """.trimIndent().toByteArray()
+        )
+        val file = MockMultipartFile(
+            "file",
+            "publication.pdf",
+            MediaType.APPLICATION_PDF_VALUE,
+            "pdf-content".toByteArray()
+        )
+
+        val responseBody = mockMvc.perform(
+            multipart("/api/publications/upload")
+                .file(metadata)
+                .file(file)
+        )
+            .andExpect(status().isCreated)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val link = objectMapper.readTree(responseBody)["link"].requiredText()
+        val relativePath = link.removePrefix("/files/").trimStart('/')
+
+        mockMvc.perform(get("/api/files/$relativePath"))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    fun `should return html error for missing pdf file`() {
+        mockMvc.perform(get("/api/files/publications/not-found.pdf"))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `should return html error for non-pdf request`() {
+        mockMvc.perform(get("/api/files/publications/not-allowed.txt"))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should reject path traversal attempts in file endpoint`() {
+        mockMvc.perform(get("/api/files/publications/../secret.pdf"))
+            .andExpect(status().isBadRequest)
+    }
+
     companion object {
         @Container
         private val postgres = PostgreSQLContainer("postgres:18")

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/StudentWorkControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/StudentWorkControllerIntegrationTest.kt
@@ -153,6 +153,36 @@ class StudentWorkControllerIntegrationTest {
         assertTrue(created["documentLink"].requiredText().startsWith("/files/student-works/"))
     }
 
+    @Test
+    fun `should reject non-pdf upload for student work`() {
+        val metadata = MockMultipartFile(
+            "metadata",
+            "",
+            MediaType.APPLICATION_JSON_VALUE,
+            """
+            {
+              "projectTypeHash": "industrial-c",
+              "authors": "Автор с файлом",
+              "theme": "Тема с файлом",
+              "published": "Публикация с файлом"
+            }
+            """.trimIndent().toByteArray()
+        )
+        val file = MockMultipartFile(
+            "file",
+            "student-work.txt",
+            MediaType.TEXT_PLAIN_VALUE,
+            "plain-text".toByteArray()
+        )
+
+        mockMvc.perform(
+            multipart("/api/student-works/upload")
+                .file(metadata)
+                .file(file)
+        )
+            .andExpect(status().isBadRequest)
+    }
+
     companion object {
         @Container
         private val postgres = PostgreSQLContainer("postgres:18")


### PR DESCRIPTION
## Что изменено

- добавлены owner-export ручки истории пожертвований в `CSV` и `PDF`
- добавлен административный reporting API по пожертвованиям: KPI, события, фильтры, пагинация и экспорт
- добавлен backend-контур продуктовых метрик: приём событий и отчёты по активности, успешности поиска и доле переходов
- улучшена локальная деградация AI assistant: при сбое внешнего GigaChat в `local/dev` профиль больше не получает `500`
- обновлены интеграционные тесты и backend-документация
- добавлены проверки на выдачу PDF-файлов и отклонение некорректных upload-запросов

## Почему

Пользовательский фронтенд уже зависит от account-ручек, админской отчётности и метрик, поэтому backend должен предоставлять эти контракты в рабочем виде. Дополнительно локальная разработка не должна ломаться из-за внешней интеграции GigaChat или невалидного trust store.

## Пользовательский и продуктовый эффект

- пользователь может выгружать историю операций из кабинета
- служебные роли получают административную отчётность по пожертвованиям
- фронтенд может отправлять и читать продуктовые метрики для ключевых пользовательских сценариев
- локальный чат с ассистентом больше не падает с `500` при недоступности внешнего AI-сервиса
- file-endpoint и upload-потоки лучше покрыты тестами

## Корневая причина исправления assistant-сбоя

Ручка `/api/assistant/chat` падала при проблемах внешнего GigaChat-контура, потому что исключение из интеграции пробрасывалось напрямую в HTTP 500. Теперь в `local/dev` профиле backend мягко деградирует до локального fallback-ответа, сохраняя историю диалога.

## Проверка

```bash
./gradlew test --tests 'com.example.poprogknowledgebaseback.AccountDonationControllerIntegrationTest' \
  --tests 'com.example.poprogknowledgebaseback.AdminDonationReportingControllerIntegrationTest' \
  --tests 'com.example.poprogknowledgebaseback.ProductMetricsControllerIntegrationTest' \
  --tests 'com.example.poprogknowledgebaseback.AiAssistantLocalFallbackIntegrationTest' \
  --tests 'com.example.poprogknowledgebaseback.AiAssistantLocalDegradationIntegrationTest' \
  --tests 'com.example.poprogknowledgebaseback.OpenApiContractIntegrationTest' \
  --tests 'com.example.poprogknowledgebaseback.PublicationControllerIntegrationTest' \
  --tests 'com.example.poprogknowledgebaseback.StudentWorkControllerIntegrationTest'
```
