### PR TITLE
[AI][BACK] Widget router and chat widget payload persistence

### DIFF
--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/assistant/AiAssistantController.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/assistant/AiAssistantController.kt
@@ -7,6 +7,10 @@ import com.example.poprogknowledgebaseback.application.assistant.AssistantDocume
 import com.example.poprogknowledgebaseback.application.assistant.AssistantDocumentRef
 import com.example.poprogknowledgebaseback.application.assistant.AssistantChatCommand
 import com.example.poprogknowledgebaseback.application.assistant.AssistantChatResult
+import com.example.poprogknowledgebaseback.application.assistant.AssistantResponseMode
+import com.example.poprogknowledgebaseback.application.assistant.AssistantWidgetActionResult
+import com.example.poprogknowledgebaseback.application.assistant.AssistantWidgetItemResult
+import com.example.poprogknowledgebaseback.application.assistant.AssistantWidgetResult
 import com.example.poprogknowledgebaseback.application.assistant.ChatHistoryMessageResult
 import com.example.poprogknowledgebaseback.application.assistant.ChatHistoryResult
 import com.example.poprogknowledgebaseback.application.assistant.ChatHistoryUseCase
@@ -95,11 +99,13 @@ class AiAssistantController(
         chatId = chatId,
         content = content,
         model = model,
+        mode = mode.name.lowercase(),
         finishReason = finishReason,
         promptTokens = promptTokens,
         completionTokens = completionTokens,
         totalTokens = totalTokens,
-        documentHints = documentHints.map { it.toDto() }
+        documentHints = documentHints.map { it.toDto() },
+        widget = widget?.toDto()
     )
 
     private fun AiAssistantDocumentRefRequest.toDomain() = AssistantDocumentRef(
@@ -120,6 +126,34 @@ class AiAssistantController(
         snippet = snippet
     )
 
+    private fun AssistantWidgetResult.toDto() = AiAssistantWidgetResponse(
+        widgetType = widgetType,
+        title = title,
+        subtitle = subtitle,
+        items = items.map { it.toDto() },
+        actions = actions.map { it.toDto() },
+        followUpOptions = followUpOptions.map { it.toDto() }
+    )
+
+    private fun AssistantWidgetItemResult.toDto() = AiAssistantWidgetItemResponse(
+        id = id,
+        title = title,
+        subtitle = subtitle,
+        meta = meta,
+        href = href,
+        prompt = prompt,
+        sourceType = sourceType,
+        sourceId = sourceId
+    )
+
+    private fun AssistantWidgetActionResult.toDto() = AiAssistantWidgetActionResponse(
+        id = id,
+        label = label,
+        kind = kind,
+        href = href,
+        prompt = prompt
+    )
+
     private fun ChatHistoryResult.toDto() = ChatHistoryResponse(
         chatId = chatId,
         messages = messages.map { it.toDto() }
@@ -129,6 +163,7 @@ class AiAssistantController(
         id = id,
         role = role.name.lowercase(),
         content = content,
+        widget = widget?.toDto(),
         createdAt = createdAt
     )
 }

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/assistant/AiAssistantDto.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/assistant/AiAssistantDto.kt
@@ -31,11 +31,41 @@ data class AiAssistantChatResponse(
     val chatId: UUID,
     val content: String,
     val model: String,
+    val mode: String,
     val finishReason: String?,
     val promptTokens: Int?,
     val completionTokens: Int?,
     val totalTokens: Int?,
-    val documentHints: List<AiAssistantDocumentHintResponse> = emptyList()
+    val documentHints: List<AiAssistantDocumentHintResponse> = emptyList(),
+    val widget: AiAssistantWidgetResponse? = null
+)
+
+data class AiAssistantWidgetResponse(
+    val widgetType: String,
+    val title: String,
+    val subtitle: String? = null,
+    val items: List<AiAssistantWidgetItemResponse> = emptyList(),
+    val actions: List<AiAssistantWidgetActionResponse> = emptyList(),
+    val followUpOptions: List<AiAssistantWidgetActionResponse> = emptyList()
+)
+
+data class AiAssistantWidgetItemResponse(
+    val id: String,
+    val title: String,
+    val subtitle: String? = null,
+    val meta: String? = null,
+    val href: String? = null,
+    val prompt: String? = null,
+    val sourceType: String? = null,
+    val sourceId: String? = null
+)
+
+data class AiAssistantWidgetActionResponse(
+    val id: String,
+    val label: String,
+    val kind: String,
+    val href: String? = null,
+    val prompt: String? = null
 )
 
 data class AiAssistantDocumentHintResponse(
@@ -60,5 +90,6 @@ data class ChatHistoryMessageResponse(
     val id: Long,
     val role: String,
     val content: String,
+    val widget: AiAssistantWidgetResponse? = null,
     val createdAt: Instant
 )

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/assistant/ChatConversationPersistenceAdapter.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/assistant/ChatConversationPersistenceAdapter.kt
@@ -46,6 +46,7 @@ class ChatConversationPersistenceAdapter(
         chatId = chatId,
         role = role,
         content = content,
+        widgetPayload = widgetPayload,
         createdAt = createdAt
     )
 
@@ -54,6 +55,7 @@ class ChatConversationPersistenceAdapter(
         chatId = chatId,
         role = role,
         content = content,
+        widgetPayload = widgetPayload,
         createdAt = createdAt
     )
 }

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/assistant/ChatMessageJpaEntity.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/persistence/assistant/ChatMessageJpaEntity.kt
@@ -25,6 +25,8 @@ class ChatMessageJpaEntity(
     val role: AiChatMessageRole,
     @Column(nullable = false, columnDefinition = "TEXT")
     val content: String,
+    @Column(name = "widget_payload", columnDefinition = "TEXT")
+    val widgetPayload: String? = null,
     @Column(name = "created_at", nullable = false)
     val createdAt: Instant
 )

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AiAssistantModels.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AiAssistantModels.kt
@@ -20,7 +20,43 @@ data class AssistantChatResult(
     val promptTokens: Int?,
     val completionTokens: Int?,
     val totalTokens: Int?,
-    val documentHints: List<AssistantDocumentHint> = emptyList()
+    val documentHints: List<AssistantDocumentHint> = emptyList(),
+    val mode: AssistantResponseMode = AssistantResponseMode.TEXT,
+    val widget: AssistantWidgetResult? = null
+)
+
+enum class AssistantResponseMode {
+    TEXT,
+    WIDGET,
+    HYBRID
+}
+
+data class AssistantWidgetResult(
+    val widgetType: String,
+    val title: String,
+    val subtitle: String? = null,
+    val items: List<AssistantWidgetItemResult> = emptyList(),
+    val actions: List<AssistantWidgetActionResult> = emptyList(),
+    val followUpOptions: List<AssistantWidgetActionResult> = emptyList()
+)
+
+data class AssistantWidgetItemResult(
+    val id: String,
+    val title: String,
+    val subtitle: String? = null,
+    val meta: String? = null,
+    val href: String? = null,
+    val prompt: String? = null,
+    val sourceType: String? = null,
+    val sourceId: String? = null
+)
+
+data class AssistantWidgetActionResult(
+    val id: String,
+    val label: String,
+    val kind: String,
+    val href: String? = null,
+    val prompt: String? = null
 )
 
 data class AssistantDocumentRef(
@@ -50,5 +86,6 @@ data class ChatHistoryMessageResult(
     val id: Long,
     val role: AiChatMessageRole,
     val content: String,
+    val widget: AssistantWidgetResult? = null,
     val createdAt: Instant
 )

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AiAssistantService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AiAssistantService.kt
@@ -16,6 +16,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.core.env.Environment
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import tools.jackson.databind.ObjectMapper
 
 @Service
 @ConditionalOnProperty(name = ["app.gigachat.enabled"], havingValue = "true")
@@ -24,8 +25,10 @@ class AiAssistantService(
     private val chatConversationPersistencePort: ChatConversationPersistencePort,
     private val documentQuestionResolver: DocumentQuestionResolver,
     private val contextPromptBuilder: AssistantContextPromptBuilder,
+    private val assistantWidgetRouter: AssistantWidgetRouter,
     private val clock: Clock,
-    private val environment: Environment
+    private val environment: Environment,
+    private val objectMapper: ObjectMapper
 ) : AiAssistantUseCase {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -48,6 +51,32 @@ class AiAssistantService(
                 ownerSub = command.requesterSub
             )
         )
+
+        val widgetResponse = assistantWidgetRouter.resolve(command)
+        if (widgetResponse != null) {
+            val widgetContent = widgetResponse.subtitle ?: widgetResponse.title
+            val assistantResponse = AiAssistantResponse(
+                content = widgetContent,
+                model = "widget-router",
+                finishReason = "stop",
+                promptTokens = null,
+                completionTokens = null,
+                totalTokens = null
+            )
+            persistConversationMessages(conversation.id, command.messages, assistantResponse, widgetResponse)
+            return AssistantChatResult(
+                chatId = conversation.id,
+                content = widgetContent,
+                model = assistantResponse.model,
+                finishReason = assistantResponse.finishReason,
+                promptTokens = assistantResponse.promptTokens,
+                completionTokens = assistantResponse.completionTokens,
+                totalTokens = assistantResponse.totalTokens,
+                documentHints = emptyList(),
+                mode = AssistantResponseMode.WIDGET,
+                widget = widgetResponse
+            )
+        }
 
         val history = chatConversationPersistencePort.findMessagesByChatIdOrderByCreatedAtAscIdAsc(conversation.id)
             .map { AiChatMessage(role = it.role, content = it.content) }
@@ -82,7 +111,8 @@ class AiAssistantService(
             promptTokens = assistantResponse.promptTokens,
             completionTokens = assistantResponse.completionTokens,
             totalTokens = assistantResponse.totalTokens,
-            documentHints = documentHints.map { it.toHint() }
+            documentHints = documentHints.map { it.toHint() },
+            mode = AssistantResponseMode.TEXT
         )
     }
 
@@ -222,7 +252,8 @@ class AiAssistantService(
     private fun persistConversationMessages(
         chatId: UUID,
         requestMessages: List<AiChatMessage>,
-        assistantResponse: AiAssistantResponse
+        assistantResponse: AiAssistantResponse,
+        widgetResponse: AssistantWidgetResult? = null
     ) {
         val now = clock.instant()
         val messages = requestMessages.mapIndexed { index, message ->
@@ -236,6 +267,7 @@ class AiAssistantService(
             chatId = chatId,
             role = AiChatMessageRole.ASSISTANT,
             content = assistantResponse.content,
+            widgetPayload = widgetResponse?.let { objectMapper.writeValueAsString(it) },
             createdAt = now.plusMillis(requestMessages.size.toLong())
         )
 

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AssistantWidgetRouter.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/AssistantWidgetRouter.kt
@@ -1,0 +1,454 @@
+package com.example.poprogknowledgebaseback.application.assistant
+
+import com.example.poprogknowledgebaseback.application.search.SearchResult
+import com.example.poprogknowledgebaseback.application.search.SearchUseCase
+import com.example.poprogknowledgebaseback.domain.assistant.AiChatMessageRole
+import com.example.poprogknowledgebaseback.domain.publication.Publication
+import com.example.poprogknowledgebaseback.domain.publication.port.PublicationPersistencePort
+import com.example.poprogknowledgebaseback.domain.studentwork.StudentWork
+import com.example.poprogknowledgebaseback.domain.studentwork.port.StudentWorkPersistencePort
+import org.springframework.stereotype.Component
+
+@Component
+class AssistantWidgetRouter(
+    private val publicationPersistencePort: PublicationPersistencePort,
+    private val studentWorkPersistencePort: StudentWorkPersistencePort,
+    private val searchUseCase: SearchUseCase
+) {
+
+    companion object {
+        private const val MAX_ITEMS = 5
+        private const val FUZZY_THRESHOLD = 0.68
+        private val EXPLANATION_PATTERNS = listOf("объясни", "сравни", "расскажи", "о чем", "о чём", "почему")
+        private val PUBLICATION_PATTERNS = listOf(
+            "какие есть публикации",
+            "какие у вас есть публикации",
+            "покажи публикации",
+            "что есть по публикациям",
+            "публикации"
+        )
+        private val WORK_PATTERNS = listOf(
+            "какие есть студенческие работы",
+            "покажи студенческие работы",
+            "покажи работы",
+            "есть ли студенческие работы",
+            "студенческие работы",
+            "дипломные работы",
+            "диссертации"
+        )
+        private val SEARCH_PATTERNS = listOf(
+            "найди",
+            "поищи",
+            "что есть",
+            "есть ли",
+            "покажи",
+            "подбери"
+        )
+        private val LANGUAGE_CATALOG_PATTERNS = listOf(
+            "какие языки есть",
+            "какие языки у вас есть",
+            "языки программирования",
+            "покажи языки программирования",
+            "покажи языки"
+        )
+        private val SUPPORTED_LANGUAGES = listOf(
+            SupportedLanguage("reflex", "Reflex", listOf("reflex"), "Процесс-ориентированный язык Poprog"),
+            SupportedLanguage("post", "poST", listOf("post", "поst"), "Процесс-ориентированное расширение Structured Text"),
+            SupportedLanguage("industrial-c", "IndustrialC", listOf("industrialc", "industrial c"), "Промышленная автоматизация и real-time")
+        )
+    }
+
+    fun resolve(command: AssistantChatCommand): AssistantWidgetResult? {
+        val userMessage = command.messages.lastOrNull { it.role == AiChatMessageRole.USER }?.content?.trim().orEmpty()
+        if (userMessage.isBlank() || command.documentRef != null) {
+            return null
+        }
+
+        val normalized = normalize(userMessage)
+        if (matchesAnyPattern(normalized, EXPLANATION_PATTERNS, threshold = 0.72)) {
+            return null
+        }
+
+        if (matchesAnyPattern(normalized, LANGUAGE_CATALOG_PATTERNS)) {
+            return buildLanguagesWidget()
+        }
+
+        val asksForPublications = containsApproximateKeyword(normalized, listOf("публикации", "публикация"))
+        val asksForWorks = containsApproximateKeyword(normalized, listOf("студенческие", "работы", "работа", "дипломные", "диссертации"))
+
+        detectLanguage(normalized)?.let { language ->
+            if (!asksForPublications && !asksForWorks) {
+                return buildLanguageBranch(language)
+            }
+        }
+
+        if (containsApproximateKeyword(normalized, listOf("публикации", "публикация"))) {
+            return buildPublicationWidget(userMessage)
+        }
+
+        if (matchesAnyPattern(normalized, PUBLICATION_PATTERNS)) {
+            return buildPublicationWidget(userMessage)
+        }
+
+        if (containsApproximateKeyword(normalized, listOf("студенческие", "работы", "работа", "дипломные", "диссертации"))) {
+            return buildStudentWorksWidget(userMessage)
+        }
+
+        if (matchesAnyPattern(normalized, WORK_PATTERNS)) {
+            return buildStudentWorksWidget(userMessage)
+        }
+
+        if (matchesAnyPattern(normalized, SEARCH_PATTERNS, threshold = 0.64) || detectLanguage(normalized) != null) {
+            return buildSearchWidget(userMessage)
+        }
+
+        return null
+    }
+
+    private fun buildPublicationWidget(userMessage: String): AssistantWidgetResult {
+        val searchQuery = extractSpecificQuery(userMessage, "публикац")
+        val useSpecificQuery = isSpecificSearchQuery(searchQuery)
+        val items = if (useSpecificQuery) {
+            searchUseCase.search(searchQuery, MAX_ITEMS * 2)
+                .filter { it.type.contains("publication") }
+                .take(MAX_ITEMS)
+                .map { it.toPublicationWidgetItem() }
+        } else {
+            publicationPersistencePort.findAllOrderByYearDescIdAsc()
+                .take(MAX_ITEMS)
+                .mapNotNull { it.toPublicationWidgetItem() }
+        }
+
+        if (items.isEmpty()) {
+            return buildEmptyResultWidget(userMessage)
+        }
+
+        return AssistantWidgetResult(
+            widgetType = "publications_list",
+            title = "Публикации",
+            subtitle = if (useSpecificQuery) "Подобрали публикации по запросу" else "Первые публикации из базы знаний",
+            items = items,
+            actions = listOf(
+                navigateAction("open-publications", "Открыть публикации", "/publications")
+            ),
+            followUpOptions = listOf(
+                promptAction("publications-reflex", "Публикации по Reflex", "Покажи публикации по Reflex"),
+                promptAction("publications-post", "Публикации по poST", "Покажи публикации по poST"),
+                promptAction("publications-industrial-c", "Публикации по IndustrialC", "Покажи публикации по IndustrialC")
+            )
+        )
+    }
+
+    private fun buildStudentWorksWidget(userMessage: String): AssistantWidgetResult {
+        val searchQuery = extractSpecificQuery(userMessage, "работ")
+        val useSpecificQuery = isSpecificSearchQuery(searchQuery)
+        val items = if (useSpecificQuery) {
+            searchUseCase.search(searchQuery, MAX_ITEMS * 2)
+                .filter { it.type.contains("student") || it.type.contains("work") }
+                .take(MAX_ITEMS)
+                .map { it.toStudentWorkWidgetItem() }
+        } else {
+            studentWorkPersistencePort.findAllOrdered()
+                .take(MAX_ITEMS)
+                .mapNotNull { it.toStudentWorkWidgetItem() }
+        }
+
+        if (items.isEmpty()) {
+            return buildEmptyResultWidget(userMessage)
+        }
+
+        return AssistantWidgetResult(
+            widgetType = "student_works_list",
+            title = "Студенческие работы",
+            subtitle = if (useSpecificQuery) "Подобрали работы по запросу" else "Первые работы из каталога",
+            items = items,
+            actions = listOf(
+                navigateAction("open-works", "Открыть раздел работ", "/works")
+            ),
+            followUpOptions = listOf(
+                promptAction("works-reflex", "Работы по Reflex", "Есть ли студенческие работы по Reflex?"),
+                promptAction("works-post", "Работы по poST", "Есть ли студенческие работы по poST?"),
+                promptAction("works-industrial-c", "Работы по IndustrialC", "Есть ли студенческие работы по IndustrialC?")
+            )
+        )
+    }
+
+    private fun buildLanguagesWidget(): AssistantWidgetResult =
+        AssistantWidgetResult(
+            widgetType = "languages_list",
+            title = "Языки программирования",
+            subtitle = "Выберите направление, и чат сразу предложит следующий шаг",
+            items = SUPPORTED_LANGUAGES.take(MAX_ITEMS + 3).map { language ->
+                AssistantWidgetItemResult(
+                    id = language.id,
+                    title = language.title,
+                    subtitle = language.description,
+                    prompt = "Что у вас есть по ${language.title}?"
+                )
+            },
+            followUpOptions = SUPPORTED_LANGUAGES.take(4).map { language ->
+                promptAction("lang-${language.id}", language.title, "Что у вас есть по ${language.title}?")
+            }
+        )
+
+    private fun buildLanguageBranch(language: SupportedLanguage): AssistantWidgetResult =
+        AssistantWidgetResult(
+            widgetType = "branch",
+            title = "Что показать по ${language.title}?",
+            subtitle = "Можно сразу перейти к типовым сценариям без обращения к LLM",
+            followUpOptions = listOf(
+                promptAction("${language.id}-publications", "Публикации", "Покажи публикации по ${language.title}"),
+                promptAction("${language.id}-works", "Студенческие работы", "Есть ли студенческие работы по ${language.title}?"),
+                promptAction("${language.id}-search", "Все материалы", "Найди материалы по ${language.title}"),
+                navigateAction("${language.id}-projects", "Проекты", "/projects")
+            )
+        )
+
+    private fun buildSearchWidget(userMessage: String): AssistantWidgetResult {
+        val items = searchUseCase.search(userMessage, MAX_ITEMS)
+        if (items.isEmpty()) {
+            return buildEmptyResultWidget(userMessage)
+        }
+
+        return AssistantWidgetResult(
+            widgetType = "search_results",
+            title = "Результаты поиска",
+            subtitle = "Первые подходящие материалы по вашему запросу",
+            items = items.map { it.toSearchWidgetItem() },
+            followUpOptions = listOf(
+                promptAction("refine-query", "Уточнить запрос", "Подбери материалы точнее: $userMessage"),
+                promptAction("explain-results", "Суммаризировать результаты", "Кратко суммаризируй, что есть по запросу: $userMessage")
+            )
+        )
+    }
+
+    private fun buildEmptyResultWidget(userMessage: String): AssistantWidgetResult =
+        AssistantWidgetResult(
+            widgetType = "empty_result",
+            title = "Точных совпадений пока нет",
+            subtitle = "Попробуйте один из быстрых вариантов уточнения",
+            followUpOptions = listOf(
+                promptAction("retry-publications", "Публикации", "Покажи публикации по теме: $userMessage"),
+                promptAction("retry-works", "Студенческие работы", "Покажи студенческие работы по теме: $userMessage"),
+                promptAction("retry-short", "Сократить запрос", shortenPrompt(userMessage))
+            )
+        )
+
+    private fun SearchResult.toSearchWidgetItem() = AssistantWidgetItemResult(
+        id = id,
+        title = theme,
+        subtitle = authors,
+        meta = published,
+        href = when {
+            type.contains("publication") -> "/publications?focusType=publication&focusId=$sourceId"
+            else -> "/works?focusType=student-work&focusId=$sourceId"
+        },
+        sourceType = type,
+        sourceId = sourceId.toString()
+    )
+
+    private fun SearchResult.toPublicationWidgetItem() = AssistantWidgetItemResult(
+        id = id,
+        title = theme,
+        subtitle = authors,
+        meta = published,
+        href = "/publications?focusType=publication&focusId=$sourceId",
+        sourceType = type,
+        sourceId = sourceId.toString()
+    )
+
+    private fun SearchResult.toStudentWorkWidgetItem() = AssistantWidgetItemResult(
+        id = id,
+        title = theme,
+        subtitle = authors,
+        meta = groupTitle,
+        href = "/works?focusType=student-work&focusId=$sourceId",
+        sourceType = type,
+        sourceId = sourceId.toString()
+    )
+
+    private fun Publication.toPublicationWidgetItem(): AssistantWidgetItemResult? {
+        val sourceId = id ?: return null
+        return AssistantWidgetItemResult(
+            id = "publication-$sourceId",
+            title = theme,
+            subtitle = authors,
+            meta = published,
+            href = "/publications?focusType=publication&focusId=$sourceId",
+            sourceType = "publication",
+            sourceId = sourceId.toString()
+        )
+    }
+
+    private fun StudentWork.toStudentWorkWidgetItem(): AssistantWidgetItemResult? {
+        val sourceId = id ?: return null
+        return AssistantWidgetItemResult(
+            id = "student-work-$sourceId",
+            title = theme,
+            subtitle = authors,
+            meta = projectTypeTitle,
+            href = "/works?focusType=student-work&focusId=$sourceId",
+            sourceType = "student-work",
+            sourceId = sourceId.toString()
+        )
+    }
+
+    private fun normalize(value: String): String =
+        " ${value.lowercase().replace(Regex("[^\\p{L}\\p{N}+/# -]"), " ").replace(Regex("\\s+"), " ").trim()} "
+
+    private fun detectLanguage(normalized: String): SupportedLanguage? =
+        SUPPORTED_LANGUAGES.firstOrNull { language ->
+            language.markers.any { marker -> fuzzyContains(normalized, normalize(marker).trim()) } ||
+                fuzzyContains(normalized, normalize(language.title).trim())
+        }
+
+    private fun extractSpecificQuery(message: String, domainMarker: String): String {
+        val lowered = message.lowercase()
+        val cleaned = lowered
+            .replace(Regex("какие у вас есть"), " ")
+            .replace(Regex("какие есть"), " ")
+            .replace(Regex("покажи"), " ")
+            .replace(Regex("что у вас есть"), " ")
+            .replace(Regex("что есть"), " ")
+            .replace(Regex("есть ли"), " ")
+            .replace(Regex("по $domainMarker\\p{L}*"), " ")
+            .replace(Regex("$domainMarker\\p{L}*"), " ")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+
+        return cleaned
+    }
+
+    private fun shortenPrompt(message: String): String {
+        val shortened = message.split(" ").filter { it.length > 2 }.take(4).joinToString(" ")
+        return if (shortened.isBlank()) "Найди похожие материалы" else "Найди материалы по теме: $shortened"
+    }
+
+    private fun isSpecificSearchQuery(searchQuery: String): Boolean {
+        val genericTokens = setOf("какие", "какая", "какое", "какой", "есть", "есь", "у", "вас", "по", "что", "покажи")
+        val meaningfulTokens = searchQuery
+            .split(" ")
+            .filter { it.isNotBlank() }
+            .filterNot { genericTokens.contains(it) }
+
+        return meaningfulTokens.size >= 1 && meaningfulTokens.joinToString(" ").length >= 4
+    }
+
+    private fun matchesAnyPattern(
+        normalizedQuery: String,
+        patterns: List<String>,
+        threshold: Double = FUZZY_THRESHOLD
+    ): Boolean = patterns.any { pattern -> fuzzyContains(normalizedQuery, pattern, threshold) }
+
+    private fun fuzzyContains(
+        normalizedQuery: String,
+        pattern: String,
+        threshold: Double = FUZZY_THRESHOLD
+    ): Boolean {
+        val normalizedPattern = normalize(pattern).trim()
+        val query = normalizedQuery.trim()
+        if (query.isBlank() || normalizedPattern.isBlank()) {
+            return false
+        }
+
+        if (query.contains(normalizedPattern)) {
+            return true
+        }
+
+        val queryTokens = query.split(" ").filter { it.isNotBlank() }
+        val patternTokens = normalizedPattern.split(" ").filter { it.isNotBlank() }
+        if (queryTokens.isEmpty() || patternTokens.isEmpty()) {
+            return false
+        }
+
+        if (phraseSimilarity(query, normalizedPattern) >= threshold) {
+            return true
+        }
+
+        val minWindow = (patternTokens.size - 1).coerceAtLeast(1)
+        val maxWindow = (patternTokens.size + 1).coerceAtMost(queryTokens.size)
+        for (windowSize in minWindow..maxWindow) {
+            for (start in 0..(queryTokens.size - windowSize)) {
+                val window = queryTokens.subList(start, start + windowSize).joinToString(" ")
+                if (phraseSimilarity(window, normalizedPattern) >= threshold) {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
+
+    private fun phraseSimilarity(left: String, right: String): Double {
+        val leftTokens = left.split(" ").filter { it.isNotBlank() }
+        val rightTokens = right.split(" ").filter { it.isNotBlank() }
+        val intersection = leftTokens.count { token -> rightTokens.contains(token) }
+        val tokenCoverage = intersection.toDouble() / rightTokens.size.coerceAtLeast(1)
+        val distance = levenshtein(left, right)
+        val maxLength = maxOf(left.length, right.length).coerceAtLeast(1)
+        val editScore = 1.0 - (distance.toDouble() / maxLength)
+        return maxOf(tokenCoverage, editScore)
+    }
+
+    private fun containsApproximateKeyword(normalizedQuery: String, keywords: List<String>): Boolean {
+        val queryTokens = normalizedQuery.trim().split(" ").filter { it.isNotBlank() }
+        return queryTokens.any { token ->
+            keywords.any { keyword ->
+                phraseSimilarity(token, normalize(keyword).trim()) >= 0.72
+            }
+        }
+    }
+
+    private fun levenshtein(left: String, right: String): Int {
+        if (left == right) {
+            return 0
+        }
+        if (left.isEmpty()) {
+            return right.length
+        }
+        if (right.isEmpty()) {
+            return left.length
+        }
+
+        val previous = IntArray(right.length + 1) { it }
+        val current = IntArray(right.length + 1)
+
+        for (leftIndex in left.indices) {
+            current[0] = leftIndex + 1
+            for (rightIndex in right.indices) {
+                val cost = if (left[leftIndex] == right[rightIndex]) 0 else 1
+                current[rightIndex + 1] = minOf(
+                    current[rightIndex] + 1,
+                    previous[rightIndex + 1] + 1,
+                    previous[rightIndex] + cost
+                )
+            }
+            for (index in previous.indices) {
+                previous[index] = current[index]
+            }
+        }
+
+        return previous[right.length]
+    }
+
+    private fun promptAction(id: String, label: String, prompt: String) = AssistantWidgetActionResult(
+        id = id,
+        label = label,
+        kind = "send_prompt",
+        prompt = prompt
+    )
+
+    private fun navigateAction(id: String, label: String, href: String) = AssistantWidgetActionResult(
+        id = id,
+        label = label,
+        kind = "navigate",
+        href = href
+    )
+}
+
+private data class SupportedLanguage(
+    val id: String,
+    val title: String,
+    val markers: List<String>,
+    val description: String
+)

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/ChatHistoryService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/ChatHistoryService.kt
@@ -2,13 +2,15 @@ package com.example.poprogknowledgebaseback.application.assistant
 
 import com.example.poprogknowledgebaseback.domain.assistant.ChatConversationNotFoundException
 import com.example.poprogknowledgebaseback.domain.assistant.port.ChatConversationPersistencePort
+import java.util.UUID
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.util.UUID
+import tools.jackson.databind.ObjectMapper
 
 @Service
 class ChatHistoryService(
-    private val chatConversationPersistencePort: ChatConversationPersistencePort
+    private val chatConversationPersistencePort: ChatConversationPersistencePort,
+    private val objectMapper: ObjectMapper
 ) : ChatHistoryUseCase {
 
     @Transactional(readOnly = true)
@@ -28,6 +30,7 @@ class ChatHistoryService(
                     id = message.id ?: error("Stored chat message id was not generated"),
                     role = message.role,
                     content = message.content,
+                    widget = message.widgetPayload?.let { objectMapper.readValue(it, AssistantWidgetResult::class.java) },
                     createdAt = message.createdAt
                 )
             }

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/NoOpAiAssistantService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/assistant/NoOpAiAssistantService.kt
@@ -13,13 +13,16 @@ import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import org.springframework.web.server.ResponseStatusException
+import tools.jackson.databind.ObjectMapper
 
 @Service
 @ConditionalOnProperty(name = ["app.gigachat.enabled"], havingValue = "false", matchIfMissing = true)
 class NoOpAiAssistantService(
     private val chatConversationPersistencePort: ChatConversationPersistencePort,
+    private val assistantWidgetRouter: AssistantWidgetRouter,
     private val clock: Clock,
-    private val environment: Environment
+    private val environment: Environment,
+    private val objectMapper: ObjectMapper
 ) : AiAssistantUseCase {
 
     @Transactional
@@ -49,6 +52,24 @@ class NoOpAiAssistantService(
             )
         )
 
+        val widgetResponse = assistantWidgetRouter.resolve(command)
+        if (widgetResponse != null) {
+            val widgetContent = widgetResponse.subtitle ?: widgetResponse.title
+            persistConversationMessages(conversation.id, command.messages, widgetContent, widgetResponse)
+            return AssistantChatResult(
+                chatId = conversation.id,
+                content = widgetContent,
+                model = "widget-router",
+                finishReason = "stop",
+                promptTokens = null,
+                completionTokens = null,
+                totalTokens = null,
+                documentHints = emptyList(),
+                mode = AssistantResponseMode.WIDGET,
+                widget = widgetResponse
+            )
+        }
+
         val lastUserMessage = command.messages.lastOrNull { it.role == AiChatMessageRole.USER }?.content?.trim().orEmpty()
         val fallbackResponse = if (lastUserMessage.isBlank()) {
             "Локальный режим: интеграция GigaChat отключена. История чата сохранена, но ответ модели сейчас недоступен."
@@ -66,7 +87,8 @@ class NoOpAiAssistantService(
             promptTokens = null,
             completionTokens = null,
             totalTokens = null,
-            documentHints = emptyList()
+            documentHints = emptyList(),
+            mode = AssistantResponseMode.TEXT
         )
     }
 
@@ -78,7 +100,8 @@ class NoOpAiAssistantService(
     private fun persistConversationMessages(
         chatId: UUID,
         requestMessages: List<com.example.poprogknowledgebaseback.domain.assistant.AiChatMessage>,
-        assistantResponse: String
+        assistantResponse: String,
+        widgetResponse: AssistantWidgetResult? = null
     ) {
         val now = clock.instant()
         val messages = requestMessages.mapIndexed { index, message ->
@@ -92,6 +115,7 @@ class NoOpAiAssistantService(
             chatId = chatId,
             role = AiChatMessageRole.ASSISTANT,
             content = assistantResponse,
+            widgetPayload = widgetResponse?.let { objectMapper.writeValueAsString(it) },
             createdAt = now.plusMillis(requestMessages.size.toLong())
         )
 

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/domain/assistant/StoredChatMessage.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/domain/assistant/StoredChatMessage.kt
@@ -8,5 +8,6 @@ data class StoredChatMessage(
     val chatId: UUID,
     val role: AiChatMessageRole,
     val content: String,
+    val widgetPayload: String? = null,
     val createdAt: Instant
 )

--- a/src/main/resources/db/changelog/017-add-widget-payload-to-chat-message.sql
+++ b/src/main/resources/db/changelog/017-add-widget-payload-to-chat-message.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chat_message
+    ADD COLUMN widget_payload TEXT;

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -31,3 +31,5 @@ databaseChangeLog:
       file: db/changelog/015-create-donation-payment-table.sql
   - include:
       file: db/changelog/016-create-product-metric-event-table.sql
+  - include:
+      file: db/changelog/017-add-widget-payload-to-chat-message.sql

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/AiAssistantControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/AiAssistantControllerIntegrationTest.kt
@@ -4,6 +4,8 @@ import com.example.poprogknowledgebaseback.domain.assistant.AiAssistantResponse
 import com.example.poprogknowledgebaseback.domain.assistant.AiChatMessage
 import com.example.poprogknowledgebaseback.domain.assistant.AiChatMessageRole
 import com.example.poprogknowledgebaseback.domain.assistant.port.AiAssistantPort
+import com.example.poprogknowledgebaseback.domain.publication.Publication
+import com.example.poprogknowledgebaseback.domain.publication.port.PublicationPersistencePort
 import java.util.UUID
 import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.test.assertEquals
@@ -46,6 +48,9 @@ class AiAssistantControllerIntegrationTest {
 
     @Autowired
     private lateinit var recordingAiAssistantPort: RecordingAiAssistantPort
+
+    @Autowired
+    private lateinit var publicationPersistencePort: PublicationPersistencePort
 
     @Test
     fun `should create chat and return persisted history`() {
@@ -161,6 +166,132 @@ class AiAssistantControllerIntegrationTest {
                     """.trimIndent()
                 )
         ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `should return publications widget without calling llm`() {
+        publicationPersistencePort.save(
+            Publication(
+                id = null,
+                year = 2025,
+                authors = "Иванов И.И.",
+                theme = "Reflex для безопасных систем управления",
+                published = "Вестник Poprog",
+                link = "https://example.org/reflex-paper.pdf"
+            )
+        )
+
+        val responseBody = mockMvc.perform(
+            post("/api/assistant/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "messages": [
+                        { "role": "user", "content": "Какие есть публикации?" }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val response = objectMapper.readTree(responseBody)
+        val chatId = UUID.fromString(response["chatId"].requiredText())
+        assertEquals("widget", response["mode"].requiredText())
+        assertEquals("publications_list", response["widget"]["widgetType"].requiredText())
+        assertTrue(response["widget"]["items"].size() > 0)
+        assertEquals(0, recordingAiAssistantPort.recordedRequests.size)
+
+        val historyBody = mockMvc.perform(get("/api/assistant/chats/{chatId}/messages", chatId))
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+        val history = objectMapper.readTree(historyBody)
+        assertEquals("publications_list", history["messages"][1]["widget"]["widgetType"].requiredText())
+    }
+
+    @Test
+    fun `should return publications widget for fuzzy matched phrase`() {
+        val responseBody = mockMvc.perform(
+            post("/api/assistant/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "messages": [
+                        { "role": "user", "content": "какие есь публикацыи" }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val response = objectMapper.readTree(responseBody)
+        assertEquals("widget", response["mode"].requiredText())
+        assertEquals("publications_list", response["widget"]["widgetType"].requiredText())
+        assertEquals(0, recordingAiAssistantPort.recordedRequests.size)
+    }
+
+    @Test
+    fun `should return branch widget for language question without calling llm`() {
+        val responseBody = mockMvc.perform(
+            post("/api/assistant/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                        """
+                    {
+                      "messages": [
+                        { "role": "user", "content": "Что у вас есть по Reflex?" }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val response = objectMapper.readTree(responseBody)
+        assertEquals("widget", response["mode"].requiredText())
+        assertEquals("branch", response["widget"]["widgetType"].requiredText())
+        assertTrue(response["widget"]["followUpOptions"].size() >= 3)
+        assertEquals(0, recordingAiAssistantPort.recordedRequests.size)
+    }
+
+    @Test
+    fun `should keep llm path for document explanation`() {
+        val responseBody = mockMvc.perform(
+            post("/api/assistant/chat")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "messages": [
+                        { "role": "user", "content": "Объясни, о чём эта публикация" }
+                      ]
+                    }
+                    """.trimIndent()
+                )
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val response = objectMapper.readTree(responseBody)
+        assertEquals("text", response["mode"].requiredText())
+        assertTrue(response["content"].requiredText().startsWith("Echo:"))
+        assertEquals(1, recordingAiAssistantPort.recordedRequests.size)
     }
 
     companion object {


### PR DESCRIPTION
## Что сделано\n- добавлен AssistantWidgetRouter для widget-first маршрутизации\n- расширен контракт /api/assistant/chat под structured widget-response\n- добавлено хранение widget payload в истории чатов\n- добавлена миграция БД для widget_payload\n- обновлены интеграционные тесты AI-чата\n\n## Проверка\n- ./gradlew test --tests 'com.example.poprogknowledgebaseback.AiAssistantControllerIntegrationTest' --tests 'com.example.poprogknowledgebaseback.AiAssistantLocalFallbackIntegrationTest' --tests 'com.example.poprogknowledgebaseback.AiAssistantLocalDegradationIntegrationTest'\n\n## Связанные задачи\n- closes #50\n- refs #83