### PR TITLE
ci: add per-service backend deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,16 @@
 .git
+.github
 .gradle
 .idea
 .kotlin
+.vscode
 build
 storage
 docs
 README.md
+.env
+.env.*
+*.local
+*.log
 *.iml
+.DS_Store

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,20 +1,26 @@
-name: Backend CI
+name: Backend CI/CD
 
 on:
   push:
     branches:
       - main
-      - master
   pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: backend-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/poprog-knowledge-base-back
 
 jobs:
   build-test:
     runs-on: ubuntu-latest
-
-    defaults:
-      run:
-        working-directory: .
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,4 +38,75 @@ jobs:
         run: ./gradlew test --no-daemon
 
       - name: Build
-        run: ./gradlew build --no-daemon -x test
+        run: ./gradlew bootJar --no-daemon
+
+  docker-deploy:
+    needs: build-test
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:latest
+
+      - name: Prepare SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "${{ secrets.DEPLOY_HOST }}" >> ~/.ssh/known_hosts
+
+      - name: Upload compose template
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+        run: |
+          scp -i ~/.ssh/deploy_key deploy/compose/docker-compose.prod.yml "$DEPLOY_USER@$DEPLOY_HOST:/home/$DEPLOY_USER/poprog-portal-backend/docker-compose.yml"
+
+      - name: Deploy backend only
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          IMAGE: ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ssh -i ~/.ssh/deploy_key "$DEPLOY_USER@$DEPLOY_HOST" \
+            "BACKEND_IMAGE='$IMAGE' GHCR_USER='$GHCR_USER' GHCR_TOKEN='$GHCR_TOKEN' bash -s" <<'REMOTE'
+          set -euo pipefail
+          cd ~/poprog-portal-backend
+          test -f .env
+          printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin >/dev/null
+          BACKEND_IMAGE="$BACKEND_IMAGE" docker compose pull portal-backend
+          BACKEND_IMAGE="$BACKEND_IMAGE" docker compose up -d portal-backend
+          docker logout ghcr.io >/dev/null
+          for attempt in $(seq 1 24); do
+            if curl -fsS http://127.0.0.1:18082/actuator/health | grep -q '"status":"UP"'; then
+              exit 0
+            fi
+            sleep 5
+          done
+          docker logs --tail=160 poprog-portal-backend >&2
+          exit 1
+          REMOTE
+
+      - name: Public smoke check
+        run: |
+          curl -fsS "http://${{ secrets.DEPLOY_HOST }}/actuator/health" | grep '"status":"UP"'
+          curl -fsS "http://${{ secrets.DEPLOY_HOST }}/api/publications/grouped" >/dev/null

--- a/deploy/compose/docker-compose.prod.yml
+++ b/deploy/compose/docker-compose.prod.yml
@@ -1,0 +1,32 @@
+services:
+  portal-backend:
+    image: ${BACKEND_IMAGE}
+    container_name: poprog-portal-backend
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      SPRING_PROFILES_ACTIVE: dev
+      DB_URL: jdbc:postgresql://postgres:5432/poprog_kb
+      DB_USER: ${POPROG_DB_USER}
+      DB_PASSWORD: ${POPROG_DB_PASSWORD}
+      SEARCH_ENABLED: "false"
+      ELASTICSEARCH_URIS: http://elasticsearch:9200
+      FILES_STORAGE_DIR: /app/storage
+      FILES_BASE_URL: /files
+      GIGACHAT_ENABLED: "false"
+      AUTH_DEV_HEADERS_ENABLED: "true"
+    ports:
+      - "127.0.0.1:18082:8080"
+    volumes:
+      - portal_backend_storage:/app/storage
+    networks:
+      - auth_ride
+
+volumes:
+  portal_backend_storage:
+
+networks:
+  auth_ride:
+    external: true
+    name: auth-ride_default

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/ProductMetricsControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/ProductMetricsControllerIntegrationTest.kt
@@ -190,7 +190,11 @@ class ProductMetricsControllerIntegrationTest {
             """.trimIndent()
         )
 
-        val dauWauBody = mockMvc.perform(get("/api/metrics/reports/dau-wau"))
+        val dauWauBody = mockMvc.perform(
+            get("/api/metrics/reports/dau-wau")
+                .queryParam("from", "2026-04-01T00:00:00Z")
+                .queryParam("to", "2026-04-03T00:00:00Z")
+        )
             .andExpect(status().isOk)
             .andReturn()
             .response
@@ -203,7 +207,11 @@ class ProductMetricsControllerIntegrationTest {
         )
         assertEquals(2, dauWauJson["daily"][0]["uniqueUsers"].asInt())
 
-        val searchSuccessBody = mockMvc.perform(get("/api/metrics/reports/search-success"))
+        val searchSuccessBody = mockMvc.perform(
+            get("/api/metrics/reports/search-success")
+                .queryParam("from", "2026-04-01T00:00:00Z")
+                .queryParam("to", "2026-04-03T00:00:00Z")
+        )
             .andExpect(status().isOk)
             .andReturn()
             .response
@@ -215,7 +223,11 @@ class ProductMetricsControllerIntegrationTest {
         assertEquals(1, searchSuccessJson["daily"][0]["successfulCount"].asInt())
         assertEquals("50.00", searchSuccessJson["daily"][0]["searchSuccessRatePercent"].asText())
 
-        val ctrBody = mockMvc.perform(get("/api/metrics/reports/ctr"))
+        val ctrBody = mockMvc.perform(
+            get("/api/metrics/reports/ctr")
+                .queryParam("from", "2026-04-01T00:00:00Z")
+                .queryParam("to", "2026-04-03T00:00:00Z")
+        )
             .andExpect(status().isOk)
             .andReturn()
             .response


### PR DESCRIPTION
Closes #55\n\n## Summary\n- add backend GitHub Actions build/test and GHCR publish\n- deploy only the backend container to poprog-edge over SSH\n- reuse the existing external auth-ride Docker network and server-side PostgreSQL env\n- add production compose template and safer Docker context ignores\n\n## Verification\n- ./gradlew bootJar --no-daemon\n- workflow/deploy diff check\n- secret scan for private keys and known server passwords\n\nNote: local ./gradlew test requires Docker/Testcontainers; Docker daemon is not running on this Mac, GitHub runner has Docker available.