### PR TITLE
ci: handle existing backend container during deploy

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -93,9 +93,13 @@ jobs:
           cd ~/poprog-portal-backend
           test -f .env
           printf '%s' "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin >/dev/null
+          trap 'docker logout ghcr.io >/dev/null 2>&1 || true' EXIT
           BACKEND_IMAGE="$BACKEND_IMAGE" docker compose pull portal-backend
+          existing_container_id="$(docker ps -aq --filter 'name=^/poprog-portal-backend$')"
+          if [ -n "$existing_container_id" ]; then
+            docker rm -f "$existing_container_id"
+          fi
           BACKEND_IMAGE="$BACKEND_IMAGE" docker compose up -d portal-backend
-          docker logout ghcr.io >/dev/null
           for attempt in $(seq 1 24); do
             if curl -fsS http://127.0.0.1:18082/actuator/health | grep -q '"status":"UP"'; then
               exit 0


### PR DESCRIPTION
Reopens #55\n\n## Summary\n- fix backend deploy failure when poprog-edge already has a legacy container named poprog-portal-backend\n- remove the existing one-off/legacy container before docker compose up so compose can recreate it from the new GHCR image\n- add a trap to always logout from GHCR on the deploy host\n\n## Root cause\nThe deploy job failed after pulling the image because Docker refused to create container /poprog-portal-backend: the name was already used by an older container outside the new compose project.\n\n## Verification\n- git diff --check\n- ./gradlew bootJar --no-daemon\n- checked the diff for private keys and known server passwords