### PR TITLE
Fix dead DOI for publication 13

### DIFF
--- a/src/main/resources/db/changelog/019-fix-publication-13-doi.sql
+++ b/src/main/resources/db/changelog/019-fix-publication-13-doi.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+
+--changeset codex:019-fix-publication-13-doi
+-- The previously stored DOI was incorrect and returned 404. Replace it with the
+-- DOI from the journal page (MathNet) and fix year/venue to keep publications
+-- page free of dead links.
+UPDATE publication
+SET
+    publication_year = 2020,
+    published = 'Моделирование и анализ информационных систем. 2020. Т. 27, № 4. С. 412-427. DOI: 10.18255/1818-1015-2020-4-412-427.',
+    link = 'https://doi.org/10.18255/1818-1015-2020-4-412-427'
+WHERE id = 13;
+

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -35,3 +35,5 @@ databaseChangeLog:
       file: db/changelog/017-add-widget-payload-to-chat-message.sql
   - include:
       file: db/changelog/018-create-stored-file-table.sql
+  - include:
+      file: db/changelog/019-fix-publication-13-doi.sql


### PR DESCRIPTION
Fixes a dead external DOI link (was returning 404) by updating publication #13 DOI/year/venue via Liquibase changeset.