### PR TITLE
fix(auth): surface Keycloak password policy errors

### DIFF
--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/account/AccountDto.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/account/AccountDto.kt
@@ -2,6 +2,7 @@ package com.example.poprogknowledgebaseback.adapters.inbound.web.account
 
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 
 data class AccountProfileResponse(
@@ -30,6 +31,10 @@ data class RegisterAccountRequest(
     @field:Size(max = 254)
     val email: String,
     @field:NotBlank
-    @field:Size(min = 8, max = 128)
+    @field:Size(min = 12, max = 128)
+    @field:Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z\\d]).+$",
+        message = "must contain lowercase, uppercase, digit and special character"
+    )
     val password: String
 )

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/keycloak/KeycloakAdminRestClient.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/keycloak/KeycloakAdminRestClient.kt
@@ -34,6 +34,10 @@ class KeycloakAdminRestClient(
                 .exchange { _, response ->
                     when (response.statusCode.value()) {
                         HttpStatus.CREATED.value() -> response.headers.location
+                        HttpStatus.BAD_REQUEST.value() -> throw ResponseStatusException(
+                            HttpStatus.BAD_REQUEST,
+                            "Keycloak rejected account data. Check password policy and email format."
+                        )
                         HttpStatus.CONFLICT.value() -> throw ResponseStatusException(
                             HttpStatus.CONFLICT,
                             "User with this email already exists in Keycloak"
@@ -46,8 +50,12 @@ class KeycloakAdminRestClient(
                 }
         } catch (ex: RestClientResponseException) {
             throw ResponseStatusException(
-                HttpStatus.BAD_GATEWAY,
-                "Keycloak user creation failed with status ${ex.statusCode.value()}",
+                if (ex.statusCode.value() == HttpStatus.BAD_REQUEST.value()) HttpStatus.BAD_REQUEST else HttpStatus.BAD_GATEWAY,
+                if (ex.statusCode.value() == HttpStatus.BAD_REQUEST.value()) {
+                    "Keycloak rejected account data. Check password policy and email format."
+                } else {
+                    "Keycloak user creation failed with status ${ex.statusCode.value()}"
+                },
                 ex
             )
         }

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/AccountControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/AccountControllerIntegrationTest.kt
@@ -50,7 +50,7 @@ class AccountControllerIntegrationTest {
             {
               "name": "Portal User",
               "email": "portal-user@example.com",
-              "password": "password123"
+              "password": "StrongPass-123!"
             }
             """.trimIndent()
 

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/KeycloakAdminRestClientTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/KeycloakAdminRestClientTest.kt
@@ -34,13 +34,13 @@ class KeycloakAdminRestClientTest {
 
             val client = KeycloakAdminRestClient(testProperties(server))
 
-            val userId = client.createUser(
-                RegisterAccountCommand(
-                    name = "Portal User",
-                    email = "portal-user@example.com",
-                    password = "password123"
-                )
-            )
+	            val userId = client.createUser(
+	                RegisterAccountCommand(
+	                    name = "Portal User",
+	                    email = "portal-user@example.com",
+	                    password = "StrongPass-123!"
+	                )
+	            )
 
             assertEquals("keycloak-user-123", userId)
 
@@ -50,10 +50,10 @@ class KeycloakAdminRestClientTest {
 
             val createRequest = server.takeRequest()
             assertEquals("/admin/realms/reflex-ide/users", createRequest.path)
-            assertEquals("Bearer admin-token", createRequest.getHeader("Authorization"))
-            val createBody = createRequest.body.readUtf8()
-            assertTrue(createBody.contains("portal-user@example.com"))
-            assertTrue(createBody.contains("password123"))
+	            assertEquals("Bearer admin-token", createRequest.getHeader("Authorization"))
+	            val createBody = createRequest.body.readUtf8()
+	            assertTrue(createBody.contains("portal-user@example.com"))
+	            assertTrue(createBody.contains("StrongPass-123!"))
             assertTrue(createBody.contains(""""emailVerified":true"""))
             assertTrue(createBody.contains(""""firstName":"Portal""""))
             assertTrue(createBody.contains(""""lastName":"User""""))
@@ -75,20 +75,49 @@ class KeycloakAdminRestClientTest {
             val client = KeycloakAdminRestClient(testProperties(server))
 
             val ex = assertThrows<ResponseStatusException> {
+	                client.createUser(
+	                    RegisterAccountCommand(
+	                        name = "Portal User",
+	                        email = "portal-user@example.com",
+	                        password = "StrongPass-123!"
+	                    )
+	                )
+	            }
+
+	            assertEquals(409, ex.statusCode.value())
+	        }
+	    }
+
+    @Test
+    fun `should translate keycloak bad request to bad request response`() {
+        MockWebServer().use { server ->
+            server.start()
+            server.enqueue(
+                MockResponse()
+                    .setResponseCode(200)
+                    .setHeader("Content-Type", "application/json")
+                    .setBody("""{"access_token":"admin-token"}""")
+            )
+            server.enqueue(MockResponse().setResponseCode(400))
+
+            val client = KeycloakAdminRestClient(testProperties(server))
+
+            val ex = assertThrows<ResponseStatusException> {
                 client.createUser(
                     RegisterAccountCommand(
                         name = "Portal User",
                         email = "portal-user@example.com",
-                        password = "password123"
+                        password = "weak"
                     )
                 )
             }
 
-            assertEquals(409, ex.statusCode.value())
+            assertEquals(400, ex.statusCode.value())
+            assertTrue(ex.reason.orEmpty().contains("password policy", ignoreCase = true))
         }
     }
 
-    private fun testProperties(server: MockWebServer) =
+	    private fun testProperties(server: MockWebServer) =
         AuthKeycloakProperties().apply {
             enabled = true
             baseUrl = server.url("/").toString().trimEnd('/')


### PR DESCRIPTION
## Summary\n- validate registration passwords against the Keycloak password policy shape\n- translate Keycloak user creation 400 responses to client 400 instead of 502 Bad Gateway\n- update account registration tests to use strong passwords and cover Keycloak bad-request translation\n\n## Verification\n- ./gradlew test --tests '*KeycloakAdminRestClientTest' --tests '*AccountControllerIntegrationTest'\n