### PR TITLE
feat(auth): восстановление пароля через API

### DIFF
--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/account/AccountController.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/account/AccountController.kt
@@ -1,6 +1,7 @@
 package com.example.poprogknowledgebaseback.adapters.inbound.web.account
 
 import com.example.poprogknowledgebaseback.application.account.AccountProfileResult
+import com.example.poprogknowledgebaseback.application.account.AccountPasswordResetService
 import com.example.poprogknowledgebaseback.application.account.AccountProfileService
 import com.example.poprogknowledgebaseback.application.account.KeycloakAccountRegistrationService
 import com.example.poprogknowledgebaseback.application.account.RegisterAccountCommand
@@ -28,7 +29,8 @@ import org.springframework.http.HttpStatus
 @Tag(name = "Личный кабинет", description = "Операции профиля текущего пользователя")
 class AccountController(
     private val accountProfileService: AccountProfileService,
-    private val keycloakAccountRegistrationService: KeycloakAccountRegistrationService
+    private val keycloakAccountRegistrationService: KeycloakAccountRegistrationService,
+    private val accountPasswordResetService: AccountPasswordResetService
 ) {
 
     @PostMapping("/register")
@@ -57,6 +59,30 @@ class AccountController(
                 password = request.password
             )
         ).toDto()
+    }
+
+    @PostMapping("/password/reset")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @Operation(
+        summary = "Запросить восстановление пароля",
+        description = "Отправляет письмо для смены пароля через Keycloak. Ответ всегда нейтральный и не раскрывает существование email."
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "202",
+                description = "Запрос принят",
+                content = [Content(schema = Schema(implementation = AccountPasswordResetResponse::class))]
+            ),
+            ApiResponse(responseCode = "400", description = "Некорректный email")
+        ]
+    )
+    fun requestPasswordReset(@Valid @RequestBody request: AccountPasswordResetRequest): AccountPasswordResetResponse {
+        accountPasswordResetService.requestReset(request.email)
+        return AccountPasswordResetResponse(
+            status = "accepted",
+            message = "Если аккаунт с таким email существует, инструкция по восстановлению пароля отправлена."
+        )
     }
 
     @GetMapping("/profile")

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/account/AccountPasswordResetDto.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/inbound/web/account/AccountPasswordResetDto.kt
@@ -1,0 +1,15 @@
+package com.example.poprogknowledgebaseback.adapters.inbound.web.account
+
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+
+data class AccountPasswordResetRequest(
+    @field:NotBlank
+    @field:Email
+    val email: String
+)
+
+data class AccountPasswordResetResponse(
+    val status: String,
+    val message: String
+)

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/keycloak/KeycloakAdminRestClient.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/adapters/outbound/keycloak/KeycloakAdminRestClient.kt
@@ -66,6 +66,44 @@ class KeycloakAdminRestClient(
             ?: throw ResponseStatusException(HttpStatus.BAD_GATEWAY, "Keycloak did not return created user id")
     }
 
+    override fun sendPasswordResetEmail(email: String) {
+        val token = requestAdminToken()
+        val userIds = findUserIdsByEmail(token, email)
+        if (userIds.isEmpty()) {
+            return
+        }
+
+        userIds.forEach { userId ->
+            try {
+                restClient.put()
+                    .uri { builder ->
+                        builder
+                            .path("/admin/realms/{realm}/users/{userId}/execute-actions-email")
+                            .queryParam("client_id", properties.clientId)
+                            .queryParam("lifespan", 900)
+                            .build(properties.realm, userId)
+                    }
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                    .body(listOf("UPDATE_PASSWORD"))
+                    .exchange { _, response ->
+                        if (response.statusCode.value() !in listOf(HttpStatus.NO_CONTENT.value(), HttpStatus.OK.value())) {
+                            throw ResponseStatusException(
+                                HttpStatus.BAD_GATEWAY,
+                                "Keycloak password reset request failed with status ${response.statusCode.value()}"
+                            )
+                        }
+                    }
+            } catch (ex: RestClientResponseException) {
+                throw ResponseStatusException(
+                    HttpStatus.BAD_GATEWAY,
+                    "Keycloak password reset request failed with status ${ex.statusCode.value()}",
+                    ex
+                )
+            }
+        }
+    }
+
     private fun requestAdminToken(): String {
         val username = properties.adminUsername.trim()
         val password = properties.adminPassword.trim()
@@ -113,6 +151,32 @@ class KeycloakAdminRestClient(
         throw ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "Keycloak base URL is not configured")
     }
 
+    private fun findUserIdsByEmail(token: String, email: String): List<String> {
+        val users = try {
+            restClient.get()
+                .uri { builder ->
+                    builder
+                        .path("/admin/realms/{realm}/users")
+                        .queryParam("email", email)
+                        .queryParam("exact", true)
+                        .queryParam("max", 3)
+                        .build(properties.realm)
+                }
+                .header(HttpHeaders.AUTHORIZATION, "Bearer $token")
+                .retrieve()
+                .body(Array<KeycloakUserSummaryResponse>::class.java)
+                .orEmpty()
+        } catch (ex: RestClientResponseException) {
+            throw ResponseStatusException(
+                HttpStatus.BAD_GATEWAY,
+                "Keycloak user lookup failed with status ${ex.statusCode.value()}",
+                ex
+            )
+        }
+
+        return users.mapNotNull { it.id?.trim() }.filter { it.isNotBlank() }
+    }
+
     private fun RegisterAccountCommand.toKeycloakUserPayload() = KeycloakCreateUserRequest(
         username = email,
         email = email,
@@ -157,5 +221,9 @@ class KeycloakAdminRestClient(
         val type: String,
         val value: String,
         val temporary: Boolean
+    )
+
+    private data class KeycloakUserSummaryResponse(
+        val id: String? = null
     )
 }

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/account/AccountPasswordResetService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/account/AccountPasswordResetService.kt
@@ -1,0 +1,32 @@
+package com.example.poprogknowledgebaseback.application.account
+
+import com.example.poprogknowledgebaseback.config.AuthKeycloakProperties
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+@Service
+class AccountPasswordResetService(
+    private val properties: AuthKeycloakProperties,
+    private val keycloakUserAdminClient: KeycloakUserAdminClient
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun requestReset(email: String) {
+        val normalizedEmail = email.trim().lowercase()
+        if (normalizedEmail.isBlank()) {
+            return
+        }
+
+        if (!properties.enabled) {
+            log.warn("Password reset requested while Keycloak integration is disabled")
+            return
+        }
+
+        try {
+            keycloakUserAdminClient.sendPasswordResetEmail(normalizedEmail)
+        } catch (error: Exception) {
+            // Deliberately swallow details to prevent account enumeration.
+            log.warn("Password reset request was not completed for email={}", normalizedEmail, error)
+        }
+    }
+}

--- a/src/main/kotlin/com/example/poprogknowledgebaseback/application/account/KeycloakAccountRegistrationService.kt
+++ b/src/main/kotlin/com/example/poprogknowledgebaseback/application/account/KeycloakAccountRegistrationService.kt
@@ -18,6 +18,7 @@ data class RegisterAccountCommand(
 
 interface KeycloakUserAdminClient {
     fun createUser(command: RegisterAccountCommand): String
+    fun sendPasswordResetEmail(email: String)
 }
 
 @Service

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/AccountControllerIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/AccountControllerIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.example.poprogknowledgebaseback
 
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.assertContains
 import com.example.poprogknowledgebaseback.application.account.KeycloakUserAdminClient
 import com.example.poprogknowledgebaseback.application.account.RegisterAccountCommand
 import org.junit.jupiter.api.Test
@@ -36,6 +37,9 @@ class AccountControllerIntegrationTest {
 
     @Autowired
     private lateinit var objectMapper: ObjectMapper
+
+    @Autowired
+    private lateinit var keycloakUserAdminClient: RecordingKeycloakUserAdminClient
 
     @Test
     fun `should return unauthorized for account profile without auth headers`() {
@@ -118,6 +122,31 @@ class AccountControllerIntegrationTest {
         assertTrue(putJson["roles"].isArray)
     }
 
+    @Test
+    fun `should accept password reset request with neutral response`() {
+        val payload =
+            """
+            {
+              "email": "portal-user@example.com"
+            }
+            """.trimIndent()
+
+        val response = mockMvc.perform(
+            post("/api/account/password/reset")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+        )
+            .andExpect(status().isAccepted)
+            .andReturn()
+            .response
+            .contentAsString
+
+        val json = objectMapper.readTree(response)
+        assertEquals("accepted", json["status"].asText())
+        assertContains(json["message"].asText(), "Если аккаунт")
+        assertEquals(listOf("portal-user@example.com"), keycloakUserAdminClient.passwordResetEmails)
+    }
+
     companion object {
         @Container
         private val postgres = PostgreSQLContainer("postgres:18")
@@ -136,10 +165,17 @@ class AccountControllerIntegrationTest {
     class KeycloakRegistrationTestConfig {
         @Bean
         @Primary
-        fun keycloakUserAdminClient(): KeycloakUserAdminClient =
-            object : KeycloakUserAdminClient {
-                override fun createUser(command: RegisterAccountCommand): String =
-                    "keycloak-created-${command.email.replace(Regex("[^a-z0-9]+"), "-").trim('-')}"
-            }
+        fun keycloakUserAdminClient(): RecordingKeycloakUserAdminClient = RecordingKeycloakUserAdminClient()
+    }
+
+    class RecordingKeycloakUserAdminClient : KeycloakUserAdminClient {
+        val passwordResetEmails = mutableListOf<String>()
+
+        override fun createUser(command: RegisterAccountCommand): String =
+            "keycloak-created-${command.email.replace(Regex("[^a-z0-9]+"), "-").trim('-')}"
+
+        override fun sendPasswordResetEmail(email: String) {
+            passwordResetEmails += email
+        }
     }
 }

--- a/src/test/kotlin/com/example/poprogknowledgebaseback/OpenApiContractIntegrationTest.kt
+++ b/src/test/kotlin/com/example/poprogknowledgebaseback/OpenApiContractIntegrationTest.kt
@@ -50,6 +50,7 @@ class OpenApiContractIntegrationTest {
         assertTrue(paths.has("/api/files/{path}"))
         assertTrue(paths.has("/api/feedback/usefulness"))
         assertTrue(paths.has("/api/account/profile"))
+        assertTrue(paths.has("/api/account/password/reset"))
         assertTrue(paths.has("/api/account/chats"))
         assertTrue(paths.has("/api/account/favorites"))
         assertTrue(paths.has("/api/account/donations"))


### PR DESCRIPTION
## Что сделано
- Добавлен endpoint `POST /api/account/password/reset`.
- Реализован сервис `AccountPasswordResetService` с нейтральным ответом (без раскрытия, существует email или нет).
- Расширена интеграция с Keycloak: поиск пользователя по email и запуск `execute-actions-email` с `UPDATE_PASSWORD`.
- Добавлены интеграционные тесты и обновлен OpenAPI-контракт.

## Почему так
- Пользователь получает восстановление пароля прямо из Poprog.
- Исключается утечка информации о наличии аккаунта (anti-enumeration).

## Проверка
- `./gradlew test --tests "*AccountControllerIntegrationTest" --tests "*OpenApiContractIntegrationTest"`

## Связанные задачи
- Closes #72
